### PR TITLE
Add read access checking

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/TestCaseDisplayService.kt
@@ -307,16 +307,21 @@ class TestCaseDisplayService(private val project: Project) {
         val descriptor = FileChooserDescriptor(true, true, false, false, false, false)
 
         // Apply filter with folders and java files with main class
-        descriptor.withFileFilter { file ->
-            file.isDirectory || (
-                file.extension?.lowercase(Locale.getDefault()) == "java" && (
-                    PsiManager.getInstance(project).findFile(file!!) as PsiJavaFile
-                    ).classes.stream().map { it.name }
-                    .toArray()
-                    .contains(
-                        (PsiManager.getInstance(project).findFile(file) as PsiJavaFile).name.removeSuffix(".java"),
+        WriteCommandAction.runWriteCommandAction(project) {
+            descriptor.withFileFilter { file ->
+                file.isDirectory || (
+                    file.extension?.lowercase(Locale.getDefault()) == "java" && (
+                        PsiManager.getInstance(project).findFile(file!!) as PsiJavaFile
+                        ).classes.stream().map { it.name }
+                        .toArray()
+                        .contains(
+                            (
+                                PsiManager.getInstance(project)
+                                    .findFile(file) as PsiJavaFile
+                                ).name.removeSuffix(".java"),
+                        )
                     )
-                )
+            }
         }
 
         val fileChooser = FileChooser.chooseFiles(


### PR DESCRIPTION
# Description of changes made
Fixing an error:
```
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read access is allowed from inside read-action or Event Dispatch Thread (EDT) only (see Application.runReadAction()); see https://jb.gg/ij-platform-threading for details
Current thread: Thread[AWT-AppKit,5,system] 125169378 (EventQueue.isDispatchThread()=false)
SystemEventQueueThread: Thread[AWT-EventQueue-0,6,main] 302538171
	at com.intellij.openapi.application.impl.ApplicationImpl.createThreadAccessException(ApplicationImpl.java:1083)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed(ApplicationImpl.java:1038)
	at com.intellij.psi.impl.PsiManagerImpl.findFile(PsiManagerImpl.java:155)
	at org.jetbrains.research.testspark.services.TestCaseDisplayService$applyTests$1.invoke(TestCaseDisplayService.kt:313)
	at org.jetbrains.research.testspark.services.TestCaseDisplayService$applyTests$1.invoke(TestCaseDisplayService.kt:310)
	at org.jetbrains.research.testspark.services.TestCaseDisplayService.applyTests$lambda$9(TestCaseDisplayService.kt:310)
	at com.intellij.openapi.fileChooser.FileChooserDescriptor.isFileSelectable(FileChooserDescriptor.java:260)
	at com.intellij.ui.mac.MacPathChooserDialog.lambda$choose$2(MacPathChooserDialog.java:96)
	at com.intellij.openapi.fileChooser.FileChooser.lambda$safeInvokeFilter$1(FileChooser.java:143)
	at java.desktop/sun.lwawt.macosx.CFileDialog.queryFilenameFilter(CFileDialog.java:188)
```

# Other notes
Closes [ICTL-793](https://youtrack.jetbrains.com/issue/ICTL-793/Add-read-access-checking)

- [x] I have checked that I am merging into correct branch
