### PR TITLE
Integrate seamless support for Windows

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/Util.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/Util.kt
@@ -2,6 +2,7 @@ package org.jetbrains.research.testspark
 
 import com.intellij.openapi.util.io.FileUtilRt
 import java.io.File
+import java.util.*
 
 class Util {
     companion object {
@@ -21,6 +22,20 @@ class Util {
             if (!dir.exists()) {
                 dir.mkdirs()
             }
+        }
+
+        val classpathSeparator: Char
+            get() {
+                var sep = ':'
+                if (isWindows()) {
+                    sep = ';'
+                }
+                return sep
+            }
+
+        fun isWindows(): Boolean {
+            val os = System.getProperty("os.name").lowercase(Locale.getDefault())
+            return (os.indexOf("win") >= 0)
         }
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/Util.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/Util.kt
@@ -2,7 +2,7 @@ package org.jetbrains.research.testspark
 
 import com.intellij.openapi.util.io.FileUtilRt
 import java.io.File
-import java.util.*
+import java.util.Locale
 
 class Util {
     companion object {

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/RunCommandLineService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/RunCommandLineService.kt
@@ -2,6 +2,7 @@ package org.jetbrains.research.testspark.services
 
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
+import org.jetbrains.research.testspark.Util
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
@@ -17,10 +18,21 @@ class RunCommandLineService(private val project: Project) {
     fun runCommandLine(cmd: ArrayList<String>): String {
         var errorMessage = ""
 
-        val process = ProcessBuilder()
-            .command("bash", "-c", cmd.joinToString(" "))
-            .redirectErrorStream(true)
-            .start()
+        /**
+         * Since Windows does not provide bash, use cmd or similar default command line interpreter
+         */
+        val process = if (Util.isWindows()) {
+                ProcessBuilder()
+                    .command("cmd", "/c", cmd.joinToString(" "))
+                    .redirectErrorStream(true)
+                    .start()
+            }
+            else {
+                ProcessBuilder()
+                    .command("bash", "-c", cmd.joinToString(" "))
+                    .redirectErrorStream(true)
+                    .start()
+            }
 
         val reader = BufferedReader(InputStreamReader(process.inputStream))
         var line: String?

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/RunCommandLineService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/RunCommandLineService.kt
@@ -22,17 +22,16 @@ class RunCommandLineService(private val project: Project) {
          * Since Windows does not provide bash, use cmd or similar default command line interpreter
          */
         val process = if (Util.isWindows()) {
-                ProcessBuilder()
-                    .command("cmd", "/c", cmd.joinToString(" "))
-                    .redirectErrorStream(true)
-                    .start()
-            }
-            else {
-                ProcessBuilder()
-                    .command("bash", "-c", cmd.joinToString(" "))
-                    .redirectErrorStream(true)
-                    .start()
-            }
+            ProcessBuilder()
+                .command("cmd", "/c", cmd.joinToString(" "))
+                .redirectErrorStream(true)
+                .start()
+        } else {
+            ProcessBuilder()
+                .command("bash", "-c", cmd.joinToString(" "))
+                .redirectErrorStream(true)
+                .start()
+        }
 
         val reader = BufferedReader(InputStreamReader(process.inputStream))
         var line: String?

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/TestCaseDisplayService.kt
@@ -462,14 +462,20 @@ class TestCaseDisplayService(private val project: Project) {
 
         // insert tests to a code
         testCaseComponents.reversed().forEach {
+            val testMethodCode = project
+                .service<JavaClassBuilderService>()
+                .getTestMethodCodeFromClassWithTestCase(
+                    project.service<JavaClassBuilderService>().formatJavaCode(
+                        it.replace("\r\n", "\n")
+                          .replace("verifyException(", "// verifyException(")
+                    )
+                )
+                // Fix Windows line separators
+                .replace("\r\n", "\n")
+
             PsiDocumentManager.getInstance(project).getDocument(outputFile)!!.insertString(
                 selectedClass.rBrace!!.textRange.startOffset,
-                // Fix Windows line separators
-                project.service<JavaClassBuilderService>().getTestMethodCodeFromClassWithTestCase(
-                    project.service<JavaClassBuilderService>().formatJavaCode(
-                        it.replace("\r\n", "\n").replace("verifyException(", "// verifyException("),
-                    ),
-                ),
+                testMethodCode,
             )
         }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/TestCaseDisplayService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/TestCaseDisplayService.kt
@@ -467,8 +467,8 @@ class TestCaseDisplayService(private val project: Project) {
                 .getTestMethodCodeFromClassWithTestCase(
                     project.service<JavaClassBuilderService>().formatJavaCode(
                         it.replace("\r\n", "\n")
-                          .replace("verifyException(", "// verifyException(")
-                    )
+                            .replace("verifyException(", "// verifyException("),
+                    ),
                 )
                 // Fix Windows line separators
                 .replace("\r\n", "\n")

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.CompilerModuleExtension
 import com.intellij.openapi.roots.ModuleRootManager
 import org.jetbrains.research.testspark.TestSparkBundle
+import org.jetbrains.research.testspark.Util
 import org.jetbrains.research.testspark.data.Report
 import org.jetbrains.research.testspark.editor.Workspace
 import org.jetbrains.research.testspark.services.ErrorService
@@ -135,8 +136,8 @@ fun getBuildPath(project: Project): String {
 
     for (module in ModuleManager.getInstance(project).modules) {
         val compilerOutputPath = CompilerModuleExtension.getInstance(module)?.compilerOutputPath
-        compilerOutputPath?.let { buildPath += compilerOutputPath.path.plus(":") }
 
+        compilerOutputPath?.let { buildPath += compilerOutputPath.path.plus(Util.classpathSeparator.toString()) }
         // Include extra libraries in classpath
         val librariesPaths = ModuleRootManager.getInstance(module).orderEntries().librariesOnly().pathsList.pathList
         for (lib in librariesPaths) {
@@ -157,7 +158,7 @@ fun getBuildPath(project: Project): String {
                 continue
             }
 
-            buildPath += lib.plus(":")
+            buildPath += lib.plus(Util.classpathSeparator.toString())
         }
     }
     return buildPath

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
@@ -18,6 +18,7 @@ import org.jetbrains.research.testspark.helpers.generateMethodDescriptor
 import org.jetbrains.research.testspark.services.SettingsProjectService
 import org.jetbrains.research.testspark.tools.evosuite.generation.EvoSuiteProcessManager
 import org.jetbrains.research.testspark.tools.template.Tool
+import java.io.File
 
 /**
  * Represents the EvoSuite class, which is a tool used to generate tests for Java code.
@@ -32,7 +33,7 @@ class EvoSuite(override val name: String = "EvoSuite") : Tool {
         val project: Project = e.project!!
         val projectClassPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path
         val settingsProjectState = project.service<SettingsProjectService>().state
-        val buildPath = "$projectClassPath/${settingsProjectState.buildPath}"
+        val buildPath = "$projectClassPath${File.separatorChar}${settingsProjectState.buildPath}"
         return EvoSuiteProcessManager(project, buildPath)
     }
 


### PR DESCRIPTION
# Description of changes made
Extended `Util` class with `classpathSeparator` property and `isWindows()` method.
* Every explicit use of classpath separator in the application (i.e. `:` for Linux) is replaced with a use of `classpathSeparator`.
* `RunCommandLineService::runCommandLine` is modified to use `cmd` command line interpreter if current OS is Windows.
* Add additional `replace` of `\r\n` with `\n` inside `TestCaseDisplayService.appendTestsToClass`.

# Why is merge request needed
It provides support Windows operating system both as a development platform and as an execution platform.

# What is missing?
~~**[IMPORTANT]:** currently cannot save generated tests into a file due to `java.lang.AssertionError: Wrong line separators` error. The error must be resolved inside this pull request.~~

**UPD(06.12.2023)**: resolved the error with file saving; it was required to add additional `replace` of `\r\n` with `\n` inside `TestCaseDisplayService.appendTestsToClass`.