### PR TITLE
Non-existent reference to a class inside plugin.xml file for a <listener> tag

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -164,9 +164,6 @@
 
     <projectListeners>
         <listener
-                class="org.jetbrains.research.testspark.listener.TestGenerationResultListenerImpl"
-                topic="org.jetbrains.research.testspark.tools.TestGenerationResultListener"/>
-        <listener
                 class="org.jetbrains.research.testspark.listener.TelemetrySubmitListenerImpl"
                 topic="com.intellij.openapi.startup.ProjectActivity"/>
         <listener


### PR DESCRIPTION
# Description of changes made
Inside a plugin.xml there is a reference inside <listener> tag to a org.jetbrains.research.testspark.listener.TestGenerationResultListenerImpl class which does not exist. It was removed in this [commit](https://github.com/JetBrains-Research/TestSpark/commit/64bd3e6be39deb4e574609dc52361aff0737d9a2#diff-45bc768345c20a063fba93e949b4d0d2908fc96a22c94ff908ce29ba8fa6c039).

# Other notes
Closes #98 

- [x] I have checked that I am merging into correct branch
