### PR TITLE
Number of passed tests is not updated properly on tests deletion

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/TestCasePanelFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/TestCasePanelFactory.kt
@@ -605,6 +605,13 @@ class TestCasePanelFactory(
     }
 
     /**
+     * Checks if the item is marked as removed.
+     *
+     * @return true if the item is removed, false otherwise.
+     */
+    fun isRemoved() = isRemoved
+
+    /**
      * Returns the indexes of lines that are modified between two lists of strings.
      *
      * @param source The source list of strings.

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/TopButtonsPanelFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/TopButtonsPanelFactory.kt
@@ -59,7 +59,9 @@ class TopButtonsPanelFactory(private val project: Project) {
     fun updateTopLabels() {
         var numberOfPassedTests = 0
         for (testCasePanelFactory in testCasePanelFactories) {
-            if (testCasePanelFactory.getError() == "") {
+            if (testCasePanelFactory.isRemoved()) continue
+            val error = testCasePanelFactory.getError()
+            if ((error is String) && error.isEmpty()) {
                 numberOfPassedTests++
             }
         }


### PR DESCRIPTION
# Description of changes made
After test generation and execution (i.e. after click on the "Run all" button) the number of passed tests is N/N. If I delete any of the test instances the total number of tests will be updated, but the number of passed tests will not, i.e. it will display as N/N-1 near the "Passed" label.

To Reproduce
Steps to reproduce the behavior:

Generate N tests
Click "Run all" button (assuming it result in N/N passed tests)
Delete any test instance -> you get N/N-1 passed tests
Expected behavior
Number of passed tests should not exceed the number of total test cases.

# Other notes
Closes #100 

- [x] I have checked that I am merging into correct branch
