### PR TITLE
Important fix of the classpath in headless mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -370,7 +370,7 @@ tasks.register<Copy>("copyJUnitRunnerLib") {
     into(libDestDir)
 }
 
-tasks.create<RunIdeTask>("headless"){
+tasks.create<RunIdeTask>("headless") {
     val root: String? by project
     val file: String? by project
     val cut: String? by project
@@ -387,7 +387,7 @@ tasks.create<RunIdeTask>("headless"){
         "-Djava.awt.headless=true",
         "--add-exports",
         "java.base/jdk.internal.vm=ALL-UNNAMED",
-        "-Didea.system.path"
+        "-Didea.system.path",
     )
 }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -45,7 +45,7 @@ class TestSparkStarter : ApplicationStarter {
         // CUT name (<package-name>.<class-name>)
         val classUnderTestName = args[3]
         // Paths to compilation output of the project under test (seperated by ':')
-        val classPath = "$projectPath/${args[4]}"
+        val classPath = "$projectPath:${args[4]}"
         // Selected mode
         val model = args[5]
         // Token

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -26,7 +26,6 @@ import org.jetbrains.research.testspark.tools.llm.generation.PromptManager
 import java.io.File
 import kotlin.system.exitProcess
 
-
 class TestSparkStarter : ApplicationStarter {
     @Deprecated("Specify it as `id` for extension definition in a plugin descriptor")
     override val commandName: String = "testspark"
@@ -37,7 +36,6 @@ class TestSparkStarter : ApplicationStarter {
     @Suppress("TooGenericExceptionCaught")
     @OptIn(ExperimentalSerializationApi::class)
     override fun main(args: List<String>) {
-
         // Project path
         val projectPath = args[1]
         // Path to the target file (.java file)
@@ -62,7 +60,7 @@ class TestSparkStarter : ApplicationStarter {
                 println("couldn't find project in $projectPath")
                 exitProcess(1)
             }
-            println("Detected project: ${project}")
+            println("Detected project: $project")
             // Continue when the project is indexed
             println("Indexing project...")
             project.let {
@@ -98,7 +96,6 @@ class TestSparkStarter : ApplicationStarter {
                         .getModuleForFile(project.service<ProjectContextService>().cutPsiClass!!.containingFile.virtualFile)!!
                     //        CompilerModuleExtension.getInstance(project.service<ProjectContextService>().cutModule!!)?.compilerOutputPath = psiFile.virtualFile
 
-
                     println("Indexing is done")
                     // get target classes
                     val classesToTest = Llm().getClassesUnderTest(project, targetPsiClass)
@@ -113,13 +110,13 @@ class TestSparkStarter : ApplicationStarter {
 
                     val llmProcessManager = LLMProcessManager(
                         project,
-                        PromptManager(project, targetPsiClass, classesToTest)
+                        PromptManager(project, targetPsiClass, classesToTest),
                     )
 
                     llmProcessManager.runTestGenerator(
                         indicator = null,
                         FragmentToTestData(CodeType.CLASS),
-                        packageName
+                        packageName,
                     )
 
                     // Run test file
@@ -152,22 +149,24 @@ class TestSparkStarter : ApplicationStarter {
                     out,
                 )
 
-                saveException(testcaseName, targetDirectory,  testExecutionError)
+                saveException(testcaseName, targetDirectory, testExecutionError)
             }
         }
     }
 
-    private fun saveException(testcaseName: String,
-                              targetDirectory: String,
-                              testExecutionError: String) {
-        if (testExecutionError.isBlank() || !testExecutionError.contains("Exception", ignoreCase = false))
+    private fun saveException(
+        testcaseName: String,
+        targetDirectory: String,
+        testExecutionError: String,
+    ) {
+        if (testExecutionError.isBlank() || !testExecutionError.contains("Exception", ignoreCase = false)) {
             return
+        }
         val targetPath = "$targetDirectory/$testcaseName-exception.log"
 
         // Save the exception
         File(targetPath).writeText(testExecutionError.replace("\tat ", "\nat "))
     }
-
 
     private fun detectPsiClass(classes: Array<PsiClass>, classUnderTestName: String): PsiClass? {
         for (psiClass in classes) {

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/TestStorageProcessingService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/TestStorageProcessingService.kt
@@ -32,7 +32,6 @@ class TestStorageProcessingService(private val project: Project) {
 
     var resultPath = "$testResultDirectory$testResultName"
 
-
     // If projectSdk is not set, it means that we are in headless mode, and we can use the JDk used for running TestSpark
     private val javaHomeDirectory = ProjectRootManager.getInstance(project).projectSdk?.homeDirectory
         ?: LocalFileSystem.getInstance().findFileByPath(System.getProperty("java.home"))!!
@@ -165,7 +164,7 @@ class TestStorageProcessingService(private val project: Project) {
         testCaseName: String,
         projectBuildPath: String,
         generatedTestPackage: String,
-        providedResultPath: String? = null
+        providedResultPath: String? = null,
     ): String {
         // find the proper javac
         val javaRunner = File(javaHomeDirectory.path).walk()
@@ -214,9 +213,9 @@ class TestStorageProcessingService(private val project: Project) {
 
         // for classpath containing cut
         command.add("--classfiles")
-        if(providedResultPath == null)
+        if (providedResultPath == null) {
             command.add(CompilerModuleExtension.getInstance(project.service<ProjectContextService>().cutModule!!)?.compilerOutputPath!!.path)
-        else
+        } else
             command.add(projectBuildPath)
 
         // for each source folder

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
@@ -133,7 +133,7 @@ fun getBuildPath(project: Project): String {
  */
 fun processStopped(project: Project, indicator: ProgressIndicator?): Boolean {
     if (project.service<ErrorService>().isErrorOccurred()) return true
-    if (indicator!= null && indicator.isCanceled) {
+    if (indicator != null && indicator.isCanceled) {
         project.service<ErrorService>().errorOccurred()
         indicator.stop()
         return true

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/PromptManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/PromptManager.kt
@@ -240,7 +240,7 @@ class PromptManager(
         interestingPsiClasses: MutableSet<PsiClass>,
         cutPsiClass: PsiClass,
     ): MutableMap<PsiClass, MutableList<PsiClass>> {
-        println("isDumb: "+DumbService.isDumb(project).toString())
+        println("isDumb: " + DumbService.isDumb(project).toString())
         val polymorphismRelations: MutableMap<PsiClass, MutableList<PsiClass>> = mutableMapOf()
 
         val psiClassesToVisit: ArrayDeque<PsiClass> = ArrayDeque(listOf(cutPsiClass))
@@ -248,17 +248,17 @@ class PromptManager(
 
 //        ApplicationManager.getApplication().runReadAction {
 //            val projectFileIndex = ProjectRootManager.getInstance(project).fileIndex
-////            projectFileIndex.iterateContent { virtualFile ->
-////                val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
-////                true
-////            }
+// //            projectFileIndex.iterateContent { virtualFile ->
+// //                val psiFile = PsiManager.getInstance(project).findFile(virtualFile)
+// //                true
+// //            }
 //        }
         interestingPsiClasses.forEach { currentInterestingClass ->
             var detectedSubClasses: Collection<PsiClass>? = null
 //            while(true){
-                val scope = GlobalSearchScope.projectScope(project)
-                val query = ClassInheritorsSearch.search(currentInterestingClass, false)
-                detectedSubClasses= query.findAll()
+            val scope = GlobalSearchScope.projectScope(project)
+            val query = ClassInheritorsSearch.search(currentInterestingClass, false)
+            detectedSubClasses = query.findAll()
             PsiShortNamesCache.getInstance(project).getClassesByName(currentInterestingClass.name!!, GlobalSearchScope.projectScope(project))
 //                if (detectedSubClasses.size >0)
 //                    break


### PR DESCRIPTION
# Description of changes made
According to the description of the parameters inside the `runTestSpark.sh`, the 4th argument (`argv[4]`) must be the classpath of the project under test, and `projectPath` (which is the 1st argument `argv[1]`) represents a path to the root directory of the project under test. Thus, these two variables must be separated with `:` in order to yield the correct classpath, otherwise the 1st entry of the provided classpath in `argv[4]` will be corrupted. 

# Why is merge request needed
The PR corrects an important aspect of test generation.

- [+] I have checked that I am merging into correct branch
