### PR TITLE
Make condition to insure ALL test cases are compilable not at least one in `TestStorageProcessingService`

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/services/TestStorageProcessingService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/TestStorageProcessingService.kt
@@ -111,15 +111,16 @@ class TestStorageProcessingService(private val project: Project) {
      *         and a String containing any error message encountered during compilation.
      */
     fun compileTestCases(generatedTestCasesPaths: List<String>, buildPath: String, testCases: MutableList<TestCaseGeneratedByLLM>): Boolean {
-        var result = false
+        var allTestCasesCompilable = true
+
         for (index in generatedTestCasesPaths.indices) {
             val compilable = compileCode(generatedTestCasesPaths[index], buildPath).first
-            result = result || compilable
+            allTestCasesCompilable = allTestCasesCompilable && compilable
             if (compilable) {
                 project.service<TestGenerationDataService>().compilableTestCases.add(testCases[index])
             }
         }
-        return result
+        return allTestCasesCompilable
     }
 
     /**


### PR DESCRIPTION
# Description of changes made
It is an old bug related to the compilation (the bug is that TestSpark requires AT LEAST one test case to be compilable instead of ALL of them be compilable). It was fixed in the `development` branch but unfortunately it leaked into this branch.

# Why is merge request needed
It fixes an old bug.

# What is missing?
*Please mention if anything is missing for this merge request, e.g you have decided to move something to the next merge request*

- [ ] I have checked that I am merging into correct branch
