### PR TITLE
Clean up test suite if all test cases are not compilable on the last feedback cycle iteration

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
@@ -103,6 +103,11 @@ class LLMProcessManager(
             // Ending loop checking
             if (isLastIteration(requestsCount) && project.service<TestGenerationDataService>().compilableTestCases.isEmpty()) {
                 llmErrorManager.errorProcess(TestSparkBundle.message("invalidLLMResult"), project)
+                if (generatedTestSuite != null) {
+                    // Cleaning up the test cases in the test suite since all of them are not compilable
+                    // Cleanup is required to preserve an invariant of the test suite containing only compilable test cases
+                    generatedTestSuite.testCases = mutableListOf()
+                }
                 break
             }
 


### PR DESCRIPTION
# Description of changes made
Clean up test suite if all test cases are not compilable on the last feedback cycle iteration

# Why is merge request needed
This change is required to preserve the invariant of the test suite containing only compilable test cases.

- [x] I have checked that I am merging into correct branch
