### PR TITLE
Add `Build Plugin` run to create the plugin archive locally

### DIFF
--- a/.run/Build Plugin.run.xml
+++ b/.run/Build Plugin.run.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build Plugin" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="buildPlugin" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
# Description of changes made
This PR adds the `Build Plugin` configuration run file to easily create the plugin archive locally in `build/distributions` in the IDE.

# Why is merge request needed
This run file can be useful to build the plugin archive and install it from the disk for development purposes. I also know it is possible to test the plugin locally with `Run Plugin`.

- [x] I have checked that I am merging into correct branch
