### PR TITLE
[ICTL-910] PsiHelper Factory that supports different languages 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ platformVersion = 2024.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins = com.intellij.java
+platformPlugins = com.intellij.java, org.jetbrains.kotlin
 
 # Java language level used to compile sources and to generate the files for - Java 17 is required since 2023.1
 javaVersion = 17

--- a/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkAction.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkAction.kt
@@ -19,7 +19,7 @@ import org.jetbrains.research.testspark.actions.template.PanelFactory
 import org.jetbrains.research.testspark.bundles.plugin.PluginLabelsBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.display.TestSparkIcons
-import org.jetbrains.research.testspark.helpers.PsiHelper
+import org.jetbrains.research.testspark.helpers.psiHelpers.PsiHelperFactory
 import org.jetbrains.research.testspark.services.EvoSuiteSettingsService
 import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.settings.evosuite.EvoSuiteSettingsState
@@ -70,7 +70,9 @@ class TestSparkAction : AnAction() {
      * @param e the AnActionEvent object representing the event
      */
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabled = PsiHelper.getCurrentListOfCodeTypes(e) != null
+        val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE)!!
+        val psiHelper = PsiHelperFactory.getPsiHelper(psiFile)
+        e.presentation.isEnabled = psiHelper.getCurrentListOfCodeTypes(e) != null
     }
 
     /**
@@ -95,9 +97,9 @@ class TestSparkAction : AnAction() {
         private val evoSuiteButton = JRadioButton("<html><b>${EvoSuite().name}</b></html>")
         private val testGeneratorButtonGroup = ButtonGroup()
 
-        private val codeTypes = PsiHelper.getCurrentListOfCodeTypes(e)!!
-
         private val psiFile: PsiFile = e.dataContext.getData(CommonDataKeys.PSI_FILE)!!
+
+        private val codeTypes = PsiHelperFactory.getPsiHelper(psiFile).getCurrentListOfCodeTypes(e)!!
         private val caretOffset: Int = e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret!!.offset
         private val fileUrl = e.dataContext.getData(CommonDataKeys.VIRTUAL_FILE)!!.presentableUrl
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/helpers/psiHelpers/JavaPsiHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/helpers/psiHelpers/JavaPsiHelper.kt
@@ -1,39 +1,20 @@
-package org.jetbrains.research.testspark.helpers
+package org.jetbrains.research.testspark.helpers.psiHelpers
 
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.editor.Caret
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiAnonymousClass
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiClassType
-import com.intellij.psi.PsiCodeBlock
-import com.intellij.psi.PsiDocumentManager
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiJavaFile
-import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiStatement
-import com.intellij.psi.PsiSubstitutor
-import com.intellij.psi.PsiType
+import com.intellij.psi.*
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import com.intellij.util.containers.stream
 import java.util.stream.Collectors
 
-// Grammar taken from: https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-4.html#jvms-4.3
+class JavaPsiHelper : PsiHelperInterface {
 
-// Implementation of functions related to PSI
-object PsiHelper {
-    /**
-     * Helper for generating method descriptors for methods.
-     *
-     * @param psiMethod the method to extract the descriptor from
-     * @return the method descriptor
-     */
-    fun generateMethodDescriptor(psiMethod: PsiMethod): String {
+    override fun generateMethodDescriptor(psiMethod: PsiMethod): String {
         val parameterTypes =
             psiMethod.getSignature(PsiSubstitutor.EMPTY)
                 .parameterTypes
@@ -46,17 +27,7 @@ object PsiHelper {
         return "${psiMethod.name}($parameterTypes)$returnType"
     }
 
-    /**
-     * Returns the surrounding PsiClass object based on the caret position within the specified PsiFile.
-     * The surrounding class is determined by finding the PsiClass objects within the PsiFile and checking
-     * if the caret is within any of them. Additionally, the found class should satisfy the constraints
-     * specified by the validateClass() function.
-     *
-     * @param psiFile The PsiFile object containing the class hierarchy.
-     * @param caretOffset The offset of the caret position within the PsiFile.
-     * @return The surrounding PsiClass object if found, null otherwise.
-     */
-    fun getSurroundingClass(
+    override fun getSurroundingClass(
         psiFile: PsiFile,
         caretOffset: Int,
     ): PsiClass? {
@@ -75,14 +46,7 @@ object PsiHelper {
         return surroundingClass
     }
 
-    /**
-     * Returns the surrounding method of the given PSI file based on the caret offset.
-     *
-     * @param psiFile The PSI file in which to search for the surrounding method.
-     * @param caretOffset The caret offset within the PSI file.
-     * @return The surrounding method if found, otherwise null.
-     */
-    fun getSurroundingMethod(
+    override fun getSurroundingMethod(
         psiFile: PsiFile,
         caretOffset: Int,
     ): PsiMethod? {
@@ -103,14 +67,7 @@ object PsiHelper {
         return surroundingMethod
     }
 
-    /**
-     * Returns the line number of the selected line where the caret is positioned.
-     *
-     * @param psiFile the PSI file where the caret is positioned
-     * @param caretOffset the caret offset within the PSI file
-     * @return the line number of the selected line, or null if unable to determine
-     */
-    fun getSurroundingLine(
+    override fun getSurroundingLine(
         psiFile: PsiFile,
         caretOffset: Int,
     ): Int? {
@@ -128,15 +85,7 @@ object PsiHelper {
         return selectedLine
     }
 
-    /**
-     * Gets the current list of code types based on the given AnActionEvent.
-     *
-     * @param e The AnActionEvent representing the current action event.
-     * @return An array containing the current code types. If no caret or PSI file is found, an empty array is returned.
-     *         The array contains the class display name, method display name (if present), and the line number (if present).
-     *         The line number is prefixed with "Line".
-     */
-    fun getCurrentListOfCodeTypes(e: AnActionEvent): Array<*>? {
+    override fun getCurrentListOfCodeTypes(e: AnActionEvent): Array<*>? {
         val result: ArrayList<String> = arrayListOf()
         val caret: Caret =
             e.dataContext.getData(CommonDataKeys.CARET)?.caretModel?.primaryCaret ?: return result.toArray()

--- a/src/main/kotlin/org/jetbrains/research/testspark/helpers/psiHelpers/PsiHelperFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/helpers/psiHelpers/PsiHelperFactory.kt
@@ -1,0 +1,16 @@
+package org.jetbrains.research.testspark.helpers.psiHelpers
+
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiJavaFile
+import org.jetbrains.kotlin.psi.KtFile
+
+object PsiHelperFactory {
+    fun getPsiHelper(psiFile: PsiFile): PsiHelperInterface {
+        return when (psiFile) {
+            is PsiJavaFile -> JavaPsiHelper()
+            // TODO implement KotlinPsiHelper class
+//            is KtFile -> KotlinPsiHelper()
+            else -> throw IllegalArgumentException("Unsupported file type")
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/research/testspark/helpers/psiHelpers/PsiHelperInterface.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/helpers/psiHelpers/PsiHelperInterface.kt
@@ -1,0 +1,59 @@
+package org.jetbrains.research.testspark.helpers.psiHelpers
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethod
+
+/**
+ * Interface that declares all the methods needed for parsing and handling the PSI (Program Structure Interface) for different languages.
+ */
+interface PsiHelperInterface {
+    /**
+     * Helper for generating method descriptors for methods.
+     *
+     * @param psiMethod the method to extract the descriptor from
+     * @return the method descriptor
+     */
+    fun generateMethodDescriptor(psiMethod: PsiMethod): String
+
+    /**
+     * Returns the surrounding PsiClass object based on the caret position within the specified PsiFile.
+     * The surrounding class is determined by finding the PsiClass objects within the PsiFile and checking
+     * if the caret is within any of them. Additionally, the found class should satisfy the constraints
+     * specified by the validateClass() function.
+     *
+     * @param psiFile The PsiFile object containing the class hierarchy.
+     * @param caretOffset The offset of the caret position within the PsiFile.
+     * @return The surrounding PsiClass object if found, null otherwise.
+     */
+    fun getSurroundingClass(psiFile: PsiFile, caretOffset: Int): PsiClass?
+
+    /**
+     * Returns the surrounding method of the given PSI file based on the caret offset.
+     *
+     * @param psiFile The PSI file in which to search for the surrounding method.
+     * @param caretOffset The caret offset within the PSI file.
+     * @return The surrounding method if found, otherwise null.
+     */
+    fun getSurroundingMethod(psiFile: PsiFile, caretOffset: Int): PsiMethod?
+
+    /**
+     * Returns the line number of the selected line where the caret is positioned.
+     *
+     * @param psiFile the PSI file where the caret is positioned
+     * @param caretOffset the caret offset within the PSI file
+     * @return the line number of the selected line, or null if unable to determine
+     */
+    fun getSurroundingLine(psiFile: PsiFile, caretOffset: Int): Int?
+
+    /**
+     * Gets the current list of code types based on the given AnActionEvent.
+     *
+     * @param e The AnActionEvent representing the current action event.
+     * @return An array containing the current code types. If no caret or PSI file is found, an empty array is returned.
+     *         The array contains the class display name, method display name (if present), and the line number (if present).
+     *         The line number is prefixed with "Line".
+     */
+    fun getCurrentListOfCodeTypes(e: AnActionEvent): Array<*>?
+}

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.research.testspark.tools
 
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.progress.ProgressIndicator
@@ -18,7 +19,7 @@ import org.jetbrains.research.testspark.data.FragmentToTestData
 import org.jetbrains.research.testspark.data.ProjectContext
 import org.jetbrains.research.testspark.data.UIContext
 import org.jetbrains.research.testspark.display.custom.IJProgressIndicator
-import org.jetbrains.research.testspark.helpers.PsiHelper
+import org.jetbrains.research.testspark.helpers.psiHelpers.PsiHelperFactory
 import org.jetbrains.research.testspark.services.CoverageVisualisationService
 import org.jetbrains.research.testspark.services.EditorService
 import org.jetbrains.research.testspark.services.TestCaseDisplayService
@@ -47,7 +48,8 @@ class Pipeline(
     val generatedTestsData = TestGenerationData()
 
     init {
-        val cutPsiClass = PsiHelper.getSurroundingClass(psiFile, caretOffset)!!
+
+        val cutPsiClass = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingClass(psiFile, caretOffset)!!
 
         // get generated test path
         val testResultDirectory = "${FileUtilRt.getTempDirectory()}${ToolUtils.sep}testSparkResults$ToolUtils.sep"

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiMethod
 import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
 import org.jetbrains.research.testspark.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
-import org.jetbrains.research.testspark.helpers.PsiHelper
+import org.jetbrains.research.testspark.helpers.psiHelpers.PsiHelperFactory
 import org.jetbrains.research.testspark.services.PluginSettingsService
 import org.jetbrains.research.testspark.tools.Pipeline
 import org.jetbrains.research.testspark.tools.evosuite.generation.EvoSuiteProcessManager
@@ -68,12 +68,12 @@ class EvoSuite(override val name: String = "EvoSuite") : Tool {
      */
     override fun generateTestsForMethod(project: Project, psiFile: PsiFile, caretOffset: Int, fileUrl: String?, testSamplesCode: String, testGenerationController: TestGenerationController) {
         log.info("Starting tests generation for method by EvoSuite")
-        val psiMethod: PsiMethod = PsiHelper.getSurroundingMethod(psiFile, caretOffset)!!
+        val psiMethod: PsiMethod = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingMethod(psiFile, caretOffset)!!
         createPipeline(project, psiFile, caretOffset, fileUrl, testGenerationController).runTestGeneration(
             getEvoSuiteProcessManager(project),
             FragmentToTestData(
                 CodeType.METHOD,
-                PsiHelper.generateMethodDescriptor(psiMethod),
+                PsiHelperFactory.getPsiHelper(psiFile).generateMethodDescriptor(psiMethod),
             ),
         )
     }
@@ -89,7 +89,7 @@ class EvoSuite(override val name: String = "EvoSuite") : Tool {
      */
     override fun generateTestsForLine(project: Project, psiFile: PsiFile, caretOffset: Int, fileUrl: String?, testSamplesCode: String, testGenerationController: TestGenerationController) {
         log.info("Starting tests generation for line by EvoSuite")
-        val selectedLine: Int = PsiHelper.getSurroundingLine(psiFile, caretOffset)?.plus(1)!!
+        val selectedLine: Int = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingLine(psiFile, caretOffset)?.plus(1)!!
         createPipeline(project, psiFile, caretOffset, fileUrl, testGenerationController).runTestGeneration(
             getEvoSuiteProcessManager(project),
             FragmentToTestData(

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -10,7 +10,7 @@ import org.jetbrains.research.testspark.actions.controllers.TestGenerationContro
 import org.jetbrains.research.testspark.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
 import org.jetbrains.research.testspark.helpers.LLMHelper
-import org.jetbrains.research.testspark.helpers.PsiHelper
+import org.jetbrains.research.testspark.helpers.psiHelpers.PsiHelperFactory
 import org.jetbrains.research.testspark.tools.Pipeline
 import org.jetbrains.research.testspark.tools.llm.generation.LLMProcessManager
 import org.jetbrains.research.testspark.tools.llm.generation.PromptManager
@@ -59,7 +59,7 @@ class Llm(override val name: String = "LLM") : Tool {
         // check if cut has any none java super class
         val maxPolymorphismDepth = SettingsArguments(project).maxPolyDepth(0)
 
-        val cutPsiClass: PsiClass = PsiHelper.getSurroundingClass(psiFile, caretOffset)!!
+        val cutPsiClass: PsiClass = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingClass(psiFile, caretOffset)!!
         var currentPsiClass = cutPsiClass
         for (index in 0 until maxPolymorphismDepth) {
             if (!classesToTest.contains(currentPsiClass)) {
@@ -108,8 +108,8 @@ class Llm(override val name: String = "LLM") : Tool {
             testGenerationController.finished()
             return
         }
-        val psiMethod: PsiMethod = PsiHelper.getSurroundingMethod(psiFile, caretOffset)!!
-        val codeType = FragmentToTestData(CodeType.METHOD, PsiHelper.generateMethodDescriptor(psiMethod))
+        val psiMethod: PsiMethod = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingMethod(psiFile, caretOffset)!!
+        val codeType = FragmentToTestData(CodeType.METHOD, PsiHelperFactory.getPsiHelper(psiFile).generateMethodDescriptor(psiMethod))
         createLLMPipeline(project, psiFile, caretOffset, fileUrl, testGenerationController).runTestGeneration(getLLMProcessManager(project, psiFile, caretOffset, testSamplesCode), codeType)
     }
 
@@ -127,7 +127,7 @@ class Llm(override val name: String = "LLM") : Tool {
             testGenerationController.finished()
             return
         }
-        val selectedLine: Int = PsiHelper.getSurroundingLine(psiFile, caretOffset)?.plus(1)!!
+        val selectedLine: Int = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingLine(psiFile, caretOffset)?.plus(1)!!
         val codeType = FragmentToTestData(CodeType.LINE, selectedLine)
         createLLMPipeline(project, psiFile, caretOffset, fileUrl, testGenerationController).runTestGeneration(getLLMProcessManager(project, psiFile, caretOffset, testSamplesCode), codeType)
     }
@@ -142,7 +142,7 @@ class Llm(override val name: String = "LLM") : Tool {
      * @return a LLMPipeline instance
      */
     private fun createLLMPipeline(project: Project, psiFile: PsiFile, caretOffset: Int, fileUrl: String?, testGenerationController: TestGenerationController): Pipeline {
-        val cutPsiClass: PsiClass = PsiHelper.getSurroundingClass(psiFile, caretOffset)!!
+        val cutPsiClass: PsiClass = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingClass(psiFile, caretOffset)!!
 
         val packageList = cutPsiClass.qualifiedName.toString().split(".").toMutableList()
         packageList.removeLast()


### PR DESCRIPTION
# Description of changes made

Before we had a PsiHelper class that implemented all the functions needed to work with Java PSIFile. Since now we want to add different languages support, this java specific class (for now JavaPsiHelper) should be an implementation of PsiHelperInterface. Then we will add KotlinPsiHelper.

So in this PR I introduced a new generic design.

# Why is merge request needed

To enable adding different languages to the plugin.

# Other notes

# What is missing?

An implementation of KotlinPsiHelper

- [x] I have checked that I am merging into correct branch
