### PR TITLE
improvement: Add Headless mode for LLM-based test generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.tasks.RunIdeTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.FileOutputStream
 import java.net.URL
@@ -360,7 +361,14 @@ tasks.register<UpdateEvoSuite>("updateEvosuite") {
     evoSuiteVersion = properties("evosuiteVersion")
 }
 
-tasks.register<Copy>("copyJUnitRunnerLib") {
+
+/**
+ * Copies the JUnitRunner.jar file to the lib directory of the project.
+ * This task depends on the "JUnitRunner" module being built beforehand.
+ * JUnitRunner.jar is required for running tests with coverage in the main plugin
+ */
+tasks.register<Copy>("copyJUnitRunnerLib")
+{
     dependsOn(":JUnitRunner:jar")
 
     val libName = "JUnitRunner.jar"
@@ -371,6 +379,39 @@ tasks.register<Copy>("copyJUnitRunnerLib") {
 
     from(libSrcPath)
     into(libDestDir)
+}
+
+/**
+ * This code sets up a Gradle task for running the plugin in headless mode
+ *
+ * @param root The root directory of the project under test.
+ * @param file The file containing unit under test.
+ * @param cut The class under test.
+ * @param cp The classpath of the project.
+ * @param llm The model used for the test generation task.
+ * @param token The token for using LLM.
+ * @param prompt a txt file containing the LLM's prompt template
+ * @param out The output directory for the project.
+ */
+tasks.create<RunIdeTask>("headless") {
+    val root: String? by project
+    val file: String? by project
+    val cut: String? by project
+    val cp: String? by project
+    val llm: String? by project
+    val token: String? by project
+    val prompt: String? by project
+    val out: String? by project
+
+    args = listOfNotNull("testspark", root, file, cut, cp, llm, token, prompt, out)
+
+    jvmArgs(
+        "-Xmx16G",
+        "-Djava.awt.headless=true",
+        "--add-exports",
+        "java.base/jdk.internal.vm=ALL-UNNAMED",
+        "-Didea.system.path",
+    )
 }
 
 fun spaceCredentialsProvided() = spaceUsername.isNotEmpty() && spacePassword.isNotEmpty()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -398,12 +398,13 @@ tasks.create<RunIdeTask>("headless") {
     val file: String? by project
     val cut: String? by project
     val cp: String? by project
+    val junitv: String? by project
     val llm: String? by project
     val token: String? by project
     val prompt: String? by project
     val out: String? by project
 
-    args = listOfNotNull("testspark", root, file, cut, cp, llm, token, prompt, out)
+    args = listOfNotNull("testspark", root, file, cut, cp, junitv, llm, token, prompt, out)
 
     jvmArgs(
         "-Xmx16G",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -360,17 +360,13 @@ abstract class UpdateEvoSuite : DefaultTask() {
 tasks.register<UpdateEvoSuite>("updateEvosuite") {
     evoSuiteVersion = properties("evosuiteVersion")
 }
-
-
 /**
  * Copies the JUnitRunner.jar file to the lib directory of the project.
  * This task depends on the "JUnitRunner" module being built beforehand.
  * JUnitRunner.jar is required for running tests with coverage in the main plugin
  */
-tasks.register<Copy>("copyJUnitRunnerLib")
-{
+tasks.register<Copy>("copyJUnitRunnerLib") {
     dependsOn(":JUnitRunner:jar")
-
     val libName = "JUnitRunner.jar"
     val libSrcDir =
         "${project.projectDir}${File.separator}JUnitRunner${File.separator}build${File.separator}libs${File.separator}"

--- a/runTestSparkHeadless.sh
+++ b/runTestSparkHeadless.sh
@@ -1,0 +1,18 @@
+# https://stackoverflow.com/a/246128
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+if uname -s | grep -iq cygwin; then
+  DIR=$(cygpath -w "$DIR")
+  PWD=$(cygpath -w "$PWD")
+fi
+echo $DIR
+
+echo "Provided arguments are $@"
+
+if [ $# -ne "10" ]; then
+  echo "$# arguments provided"
+  echo "needs 10 arguments with the following order: 1- project under test root path 2- CUT-File-directory, 3-CUT qualified name, 4-Classpaths containing the compiled project, 5-Model name, 6-Grazie toke 7-.txt file containing prompt template 8- output directory 9-Space username 10-Space password"
+  exit 1
+fi
+
+
+"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pllm="$5" -Ptoken="$6" -Pprompt="$7" -Pout="$8" -Dspace.username="$9" -Dspace.pass="${10}"

--- a/runTestSparkHeadless.sh
+++ b/runTestSparkHeadless.sh
@@ -11,7 +11,7 @@ echo $DIR
 echo "Provided arguments are $@"
 
 if [ $# -ne "11" ]; then
-  echo "$# arguments provided, expected 10 arguments in the following order:
+  echo "$# arguments provided, expected 11 arguments in the following order:
         1) Path to the root directory of the project under test (ProjectPath)
         2) Path to the target file (.java file) (it MUST be relative to the ProjectPath)
         3) Qualified name of the class under test (i.e., <package-name>.<class-name>)

--- a/runTestSparkHeadless.sh
+++ b/runTestSparkHeadless.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # https://stackoverflow.com/a/246128
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 if uname -s | grep -iq cygwin; then
@@ -9,10 +11,20 @@ echo $DIR
 echo "Provided arguments are $@"
 
 if [ $# -ne "11" ]; then
-  echo "$# arguments provided"
-  echo "needs 10 arguments with the following order: 1- project under test root path 2- CUT-File-directory, 3-CUT qualified name, 4-Classpaths containing the compiled project, 5- JUnitVersion ('4' or '5'), 6-Model name, 7-Grazie toke 8-.txt file containing prompt template 9- output directory 10-Space username 11-Space password"
+  echo "$# arguments provided, expected 10 arguments in the following order:
+        1) Path to the root directory of the project under test (ProjectPath)
+        2) Path to the target file (.java file) (it MUST be relative to the ProjectPath)
+        3) Qualified name of the class under test (i.e., <package-name>.<class-name>)
+        4) Classpaths containing the compiled project (separated by ':')
+        5) Version of JUnit testing framework (either 4 or 5)
+        6) Model name (e.g., GPT-4)
+        7) Grazie token
+        8) Filepath to a txt-file containing prompt template
+        9) Output directory
+        10) Space username
+        11) Space password"
   exit 1
 fi
 
 
-"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pjunitv="$5" -Pllm="$6" -Ptoken="$7" -Pprompt="$8" -Pout="$9" -Dspace.username="$10" -Dspace.pass="${11}"
+"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pjunitv="$5" -Pllm="$6" -Ptoken="$7" -Pprompt="$8" -Pout="$9" -Dspace.username="${10}" -Dspace.pass="${11}"

--- a/runTestSparkHeadless.sh
+++ b/runTestSparkHeadless.sh
@@ -8,11 +8,11 @@ echo $DIR
 
 echo "Provided arguments are $@"
 
-if [ $# -ne "10" ]; then
+if [ $# -ne "11" ]; then
   echo "$# arguments provided"
-  echo "needs 10 arguments with the following order: 1- project under test root path 2- CUT-File-directory, 3-CUT qualified name, 4-Classpaths containing the compiled project, 5-Model name, 6-Grazie toke 7-.txt file containing prompt template 8- output directory 9-Space username 10-Space password"
+  echo "needs 10 arguments with the following order: 1- project under test root path 2- CUT-File-directory, 3-CUT qualified name, 4-Classpaths containing the compiled project, 5- JUnitVersion ('4' or '5'), 6-Model name, 7-Grazie toke 8-.txt file containing prompt template 9- output directory 10-Space username 11-Space password"
   exit 1
 fi
 
 
-"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pllm="$5" -Ptoken="$6" -Pprompt="$7" -Pout="$8" -Dspace.username="$9" -Dspace.pass="${10}"
+"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pjunitv="$5" -Pllm="$6" -Ptoken="$7" -Pprompt="$8" -Pout="$9" -Dspace.username="$10" -Dspace.pass="${11}"

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -93,6 +93,7 @@ class TestSparkStarter : ApplicationStarter {
                     settingsState.grazieToken = token
                     settingsState.grazieModel = model
                     settingsState.classPrompts = JsonEncoding.encode(mutableListOf(File(promptTemplateFile).readText()))
+//                    settingsState.junitVersion = JUnitVersion.JUnit4 or JUnitVersion.JUnit5 ToDo: add a new parameter
                     project.service<PluginSettingsService>().state.buildPath = classPath
 
                     // Prepare Project Context
@@ -109,14 +110,11 @@ class TestSparkStarter : ApplicationStarter {
                         cutModule
                     )
                     // Prepare the test generation data
-
-//                    generatedTestsData.baseDir = "${testResultDirectory}$testResultName-validation"
-//                    generatedTestsData.testResultName = testResultName
                     val testGenerationData =  TestGenerationData(
                         resultPath = output,
                         testResultName = "HeadlessGeneratedTests"
                     )
-                    println("[TestSpark Starter]Indexing is done")
+                    println("[TestSpark Starter] Indexing is done")
 
                     // get package name
                     val packageList = targetPsiClass.qualifiedName.toString().split(".").toMutableList()
@@ -130,6 +128,8 @@ class TestSparkStarter : ApplicationStarter {
                             psiFile,
                             targetPsiClass.textRange.startOffset,
                             "")
+
+                    println("[TestSpark Starter] Starting the test generation process")
                     // Start test generation
                     val indicator = HeadlessProgressIndicator()
                     val errorMonitor = DefaultErrorMonitor()
@@ -168,7 +168,7 @@ class TestSparkStarter : ApplicationStarter {
                 println("Running test ${it.name}")
                 var testcaseName = it.nameWithoutExtension.removePrefix("Generated")
                 testcaseName = testcaseName[0].lowercaseChar() + testcaseName.substring(1)
-                // Test is compiled and it is ready to run jacoco
+                // The current test is compiled and is ready to run jacoco
                 val testExecutionError = TestProcessor(project).createXmlFromJacoco(
                     it.nameWithoutExtension,
                     "$targetDirectory${File.separator}jacoco-${it.nameWithoutExtension}",
@@ -178,7 +178,7 @@ class TestSparkStarter : ApplicationStarter {
                     out,
                     projectContext
                 )
-
+                // Saving exception (if exists) thrown during the test execution
                 saveException(testcaseName, targetDirectory, testExecutionError)
             }
         }

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -14,6 +14,7 @@ import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiManager
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.jetbrains.research.testspark.bundles.llm.LLMDefaultsBundle
+import org.jetbrains.research.testspark.core.data.JUnitVersion
 import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
 import org.jetbrains.research.testspark.data.CodeType
@@ -51,14 +52,16 @@ class TestSparkStarter : ApplicationStarter {
         val classUnderTestName = args[3]
         // Paths to compilation output of the project under test (seperated by ':')
         val classPath = "$projectPath${ToolUtils.sep}${args[4]}"
+        // JUnit Version
+        val jUnitVersion = args[5]
         // Selected mode
-        val model = args[5]
+        val model = args[6]
         // Token
-        val token = args[6]
+        val token = args[7]
         // A txt file containing the prompt template
-        val promptTemplateFile = args[7]
+        val promptTemplateFile = args[8]
         // Output directory
-        val output = args[8]
+        val output = args[9]
 
         println("Test generation requested for $projectPath")
 
@@ -93,7 +96,13 @@ class TestSparkStarter : ApplicationStarter {
                     settingsState.grazieToken = token
                     settingsState.grazieModel = model
                     settingsState.classPrompts = JsonEncoding.encode(mutableListOf(File(promptTemplateFile).readText()))
-//                    settingsState.junitVersion = JUnitVersion.JUnit4 or JUnitVersion.JUnit5 ToDo: add a new parameter
+                    settingsState.junitVersion = when(jUnitVersion.filter{it.isDigit()}){
+                        "4" -> JUnitVersion.JUnit4
+                        "5" -> JUnitVersion.JUnit5
+                        else -> {
+                            throw IllegalArgumentException("JUnit version $jUnitVersion is not supported. Supported JUnit versions are '4' and '5'")
+                        }
+                    }
                     project.service<PluginSettingsService>().state.buildPath = classPath
 
                     // Prepare Project Context

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -92,11 +92,11 @@ class TestSparkStarter : ApplicationStarter {
 
                     // update settings
                     val settingsState = project.getService(LLMSettingsService::class.java).state
-                    settingsState.currentLLMPlatformName =  LLMDefaultsBundle.get("grazieName")
+                    settingsState.currentLLMPlatformName = LLMDefaultsBundle.get("grazieName")
                     settingsState.grazieToken = token
                     settingsState.grazieModel = model
                     settingsState.classPrompts = JsonEncoding.encode(mutableListOf(File(promptTemplateFile).readText()))
-                    settingsState.junitVersion = when(jUnitVersion.filter{it.isDigit()}){
+                    settingsState.junitVersion = when (jUnitVersion.filter { it.isDigit() }) {
                         "4" -> JUnitVersion.JUnit4
                         "5" -> JUnitVersion.JUnit5
                         else -> {
@@ -119,7 +119,7 @@ class TestSparkStarter : ApplicationStarter {
                         cutModule
                     )
                     // Prepare the test generation data
-                    val testGenerationData =  TestGenerationData(
+                    val testGenerationData = TestGenerationData(
                         resultPath = output,
                         testResultName = "HeadlessGeneratedTests"
                     )
@@ -136,7 +136,8 @@ class TestSparkStarter : ApplicationStarter {
                             project,
                             psiFile,
                             targetPsiClass.textRange.startOffset,
-                            "")
+                            ""
+                        )
 
                     println("[TestSpark Starter] Starting the test generation process")
                     // Start test generation
@@ -149,16 +150,16 @@ class TestSparkStarter : ApplicationStarter {
                         projectContext,
                         testGenerationData,
                         errorMonitor
-                        )
+                    )
 
                     // Check test Generation Output
                     if (uiContext != null) {
-                            println("[TestSpark Starter] Test generation completed successfully")
-                            // Run test file
-                            runTests(project, output, packageList, classPath, projectContext)
-                        } else {
-                            println("[TestSpark Starter] Test generation failed")
-                        }
+                        println("[TestSpark Starter] Test generation completed successfully")
+                        // Run test file
+                        runTests(project, output, packageList, classPath, projectContext)
+                    } else {
+                        println("[TestSpark Starter] Test generation failed")
+                    }
 
                     ProjectManager.getInstance().closeAndDispose(project)
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -116,7 +116,7 @@ class TestSparkStarter : ApplicationStarter {
                         resultPath = output,
                         testResultName = "HeadlessGeneratedTests"
                     )
-                    println("Indexing is done")
+                    println("[TestSpark Starter]Indexing is done")
 
                     // get package name
                     val packageList = targetPsiClass.qualifiedName.toString().split(".").toMutableList()
@@ -131,19 +131,25 @@ class TestSparkStarter : ApplicationStarter {
                             targetPsiClass.textRange.startOffset,
                             "")
                     // Start test generation
+                    val indicator = HeadlessProgressIndicator()
+                    val errorMonitor = DefaultErrorMonitor()
                     val uiContext = llmProcessManager.runTestGenerator(
-                        HeadlessProgressIndicator(),
+                        indicator,
                         FragmentToTestData(CodeType.CLASS),
                         packageName,
                         projectContext,
                         testGenerationData,
-                        DefaultErrorMonitor()
+                        errorMonitor
                         )
 
-
-
-                    // Run test file
-                    runTests(project, output, packageList, classPath, projectContext)
+                    // Check test Generation Output
+                    if (uiContext != null) {
+                            println("[TestSpark Starter] Test generation completed successfully")
+                            // Run test file
+                            runTests(project, output, packageList, classPath, projectContext)
+                        } else {
+                            println("[TestSpark Starter] Test generation failed")
+                        }
 
                     ProjectManager.getInstance().closeAndDispose(project)
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -1,0 +1,200 @@
+package org.jetbrains.research.testspark.appstarter
+
+import com.intellij.ide.impl.ProjectUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ApplicationStarter
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiManager
+import kotlinx.serialization.ExperimentalSerializationApi
+import org.jetbrains.research.testspark.bundles.llm.LLMDefaultsBundle
+import org.jetbrains.research.testspark.core.data.TestGenerationData
+import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
+import org.jetbrains.research.testspark.data.CodeType
+import org.jetbrains.research.testspark.data.FragmentToTestData
+import org.jetbrains.research.testspark.data.ProjectContext
+import org.jetbrains.research.testspark.data.llm.JsonEncoding
+import org.jetbrains.research.testspark.progress.HeadlessProgressIndicator
+import org.jetbrains.research.testspark.services.LLMSettingsService
+import org.jetbrains.research.testspark.services.PluginSettingsService
+import org.jetbrains.research.testspark.tools.llm.Llm
+import java.io.File
+import kotlin.system.exitProcess
+
+/**
+ * This class represents a test spark starter that implements the ApplicationStarter interface.
+ * It is responsible for generating and running tests based on the provided arguments in headless mode.
+ */
+class TestSparkStarter : ApplicationStarter {
+    @Deprecated("Specify it as `id` for extension definition in a plugin descriptor")
+    override val commandName: String = "testspark"
+
+    /** Sets main (start) thread for IDE in headless as not edt. */
+    override val requiredModality: Int = ApplicationStarter.NOT_IN_EDT
+
+    @Suppress("TooGenericExceptionCaught")
+    @OptIn(ExperimentalSerializationApi::class)
+    override fun main(args: List<String>) {
+        // Project path
+        val projectPath = args[1]
+        // Path to the target file (.java file)
+        val filePath = "$projectPath/${args[2]}"
+        // CUT name (<package-name>.<class-name>)
+        val classUnderTestName = args[3]
+        // Paths to compilation output of the project under test (seperated by ':')
+        val classPath = "$projectPath:${args[4]}"
+        // Selected mode
+        val model = args[5]
+        // Token
+        val token = args[6]
+        // A txt file containing the prompt template
+        val promptTemplateFile = args[7]
+        // Output directory
+        val output = args[8]
+
+        println("Test generation requested for $projectPath")
+
+        ApplicationManager.getApplication().invokeAndWait {
+            val project = ProjectUtil.openOrImport(projectPath, null, true) ?: run {
+                println("couldn't find project in $projectPath")
+                exitProcess(1)
+            }
+            println("Detected project: $project")
+            // Continue when the project is indexed
+            println("Indexing project...")
+            project.let {
+                DumbService.getInstance(it).runWhenSmart {
+                    // open target file
+                    val virtualFile = LocalFileSystem.getInstance().findFileByPath(filePath) ?: run {
+                        println("couldn't open file $filePath")
+                        exitProcess(1)
+                    }
+
+                    // get target PsiClass
+                    val psiFile = PsiManager.getInstance(project).findFile(virtualFile) as PsiJavaFile
+                    val targetPsiClass = detectPsiClass(psiFile.classes, classUnderTestName) ?: run {
+                        println("couldn't find $classUnderTestName in $filePath")
+                        exitProcess(1)
+                    }
+
+                    println("PsiClass ${targetPsiClass.qualifiedName} is detected! Start the test generation process.")
+
+                    // update settings
+                    val settingsState = project.getService(LLMSettingsService::class.java).state
+                    settingsState.currentLLMPlatformName =  LLMDefaultsBundle.get("grazieName")
+                    settingsState.grazieToken = token
+                    settingsState.grazieModel = model
+                    settingsState.classPrompts = JsonEncoding.encode(mutableListOf(File(promptTemplateFile).readText()))
+                    project.service<PluginSettingsService>().state.buildPath = classPath
+
+                    // Prepare Project Context
+                    // First, get CUT Module
+                    val cutModule =
+                        ProjectFileIndex.getInstance(project)
+                            .getModuleForFile(targetPsiClass.containingFile.virtualFile)!!
+                    // Then, instantiate the project context
+                    val projectContext = ProjectContext(
+                        classPath,
+                        output,
+                        targetPsiClass,
+                        targetPsiClass.qualifiedName,
+                        cutModule
+                    )
+                    // Prepare the test generation data
+
+//                    generatedTestsData.baseDir = "${testResultDirectory}$testResultName-validation"
+//                    generatedTestsData.testResultName = testResultName
+                    val testGenerationData =  TestGenerationData(
+                        resultPath = output,
+                        testResultName = "HeadlessGeneratedTests"
+                    )
+                    println("Indexing is done")
+
+                    // get package name
+                    val packageList = targetPsiClass.qualifiedName.toString().split(".").toMutableList()
+                    packageList.removeLast()
+                    val packageName = packageList.joinToString(".")
+
+                    // Create a process Manager
+                    val llmProcessManager = Llm()
+                        .getLLMProcessManager(
+                            project,
+                            psiFile,
+                            targetPsiClass.textRange.startOffset,
+                            "")
+                    // Start test generation
+                    val uiContext = llmProcessManager.runTestGenerator(
+                        HeadlessProgressIndicator(),
+                        FragmentToTestData(CodeType.CLASS),
+                        packageName,
+                        projectContext,
+                        testGenerationData,
+                        DefaultErrorMonitor()
+                        )
+
+
+
+                    // Run test file
+                    // ToDO: run tests
+//                    runTests(project, output, packageList, classPath)
+
+                    ProjectManager.getInstance().closeAndDispose(project)
+
+                    println("[TestSpark Starter] Exiting the headless mode")
+                    exitProcess(0)
+                }
+            }
+        }
+    }
+
+//    private fun runTests(project: Project, out: String, packageList: MutableList<String>, classPath: String) {
+//        val targetDirectory = "$out${File.separator}${packageList.joinToString(File.separator)}"
+//        println("Run tests in $targetDirectory")
+//        File(targetDirectory).walk().forEach {
+//            if (it.name.endsWith(".class")) {
+//                println("Running test ${it.name}")
+//                var testcaseName = it.nameWithoutExtension.removePrefix("Generated")
+//                testcaseName = testcaseName[0].lowercaseChar() + testcaseName.substring(1)
+//                // Test is compiled and it is ready to run jacoco
+//                val testExecutionError = project.service<TestStorageProcessingService>().createXmlFromJacoco(
+//                    it.nameWithoutExtension,
+//                    "$targetDirectory${File.separator}jacoco-${it.nameWithoutExtension}",
+//                    testcaseName,
+//                    classPath,
+//                    packageList.joinToString("."),
+//                    out,
+//                )
+//
+//                saveException(testcaseName, targetDirectory, testExecutionError)
+//            }
+//        }
+//    }
+
+    private fun saveException(
+        testcaseName: String,
+        targetDirectory: String,
+        testExecutionError: String,
+    ) {
+        if (testExecutionError.isBlank() || !testExecutionError.contains("Exception", ignoreCase = false)) {
+            return
+        }
+        val targetPath = "$targetDirectory/$testcaseName-exception.log"
+
+        // Save the exception
+        File(targetPath).writeText(testExecutionError.replace("\tat ", "\nat "))
+    }
+
+    private fun detectPsiClass(classes: Array<PsiClass>, classUnderTestName: String): PsiClass? {
+        for (psiClass in classes) {
+            if (psiClass.qualifiedName == classUnderTestName) {
+                return psiClass
+            }
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -136,7 +136,7 @@ class TestSparkStarter : ApplicationStarter {
                             project,
                             psiFile,
                             targetPsiClass.textRange.startOffset,
-                            testSamplesCode = "" // we dont provide samples to LLM
+                            testSamplesCode = "" // we don't provide samples to LLM
                         )
 
                     println("[TestSpark Starter] Starting the test generation process")

--- a/src/main/kotlin/org/jetbrains/research/testspark/progress/HeadlessProgressIndicator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/progress/HeadlessProgressIndicator.kt
@@ -6,7 +6,7 @@ import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
  * A class that mocking the IDE progress indicator in headless environment.
  * It implements the CustomProgressIndicator interface.
  */
-class HeadlessProgressIndicator: CustomProgressIndicator {
+class HeadlessProgressIndicator : CustomProgressIndicator {
     override fun setText(text: String) {}
 
     override fun getText(): String = ""

--- a/src/main/kotlin/org/jetbrains/research/testspark/progress/HeadlessProgressIndicator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/progress/HeadlessProgressIndicator.kt
@@ -1,0 +1,29 @@
+package org.jetbrains.research.testspark.progress
+
+import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
+
+/**
+ * A class that mocking the IDE progress indicator in headless environment.
+ * It implements the CustomProgressIndicator interface.
+ */
+class HeadlessProgressIndicator: CustomProgressIndicator {
+    override fun setText(text: String) {}
+
+    override fun getText(): String = ""
+
+    override fun setIndeterminate(value: Boolean) {}
+
+    override fun isIndeterminate(): Boolean = false
+
+    override fun setFraction(value: Double) {}
+
+    override fun getFraction(): Double = 0.0
+
+    override fun cancel() {}
+
+    override fun isCanceled(): Boolean = false
+
+    override fun start() {}
+
+    override fun stop() {}
+}

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
@@ -51,7 +51,7 @@ class Pipeline(
         val cutPsiClass = PsiHelperFactory.getPsiHelper(psiFile).getSurroundingClass(psiFile, caretOffset)!!
 
         // get generated test path
-        val testResultDirectory = "${FileUtilRt.getTempDirectory()}${ToolUtils.sep}testSparkResults$ToolUtils.sep"
+        val testResultDirectory = "${FileUtilRt.getTempDirectory()}${ToolUtils.sep}testSparkResults${ToolUtils.sep}"
         val id = UUID.randomUUID().toString()
         val testResultName = "test_gen_result_$id"
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -58,7 +58,7 @@ class TestProcessor(val project: Project) : TestsPersistentStorage {
      * @param generatedTestPackage The package where the generated test class is located.
      * @return An empty string if the test execution is successful, otherwise an error message.
      */
-    private fun createXmlFromJacoco(
+    fun createXmlFromJacoco(
         className: String,
         dataFileName: String,
         testCaseName: String,

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -93,7 +93,7 @@ class TestProcessor(val project: Project) : TestsPersistentStorage {
                 javaRunner.absolutePath,
                 "-javaagent:$jacocoAgentLibraryPath=destfile=$dataFileName.exec,append=false,includes=${projectContext.classFQN}",
                 "-cp",
-                "\"${testCompiler.getPath(projectBuildPath)}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath\"",
+                "\"${testCompiler.getPath(projectBuildPath)}${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath\"",
                 "org.jetbrains.research.SingleJUnitTestRunner$junitVersion",
                 name,
             ),

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -32,7 +32,7 @@ class Llm(override val name: String = "LLM") : Tool {
      * @param testSamplesCode The test samples code.
      * @return An instance of LLMProcessManager.
      */
-    private fun getLLMProcessManager(project: Project, psiFile: PsiFile, caretOffset: Int, testSamplesCode: String): LLMProcessManager {
+    fun getLLMProcessManager(project: Project, psiFile: PsiFile, caretOffset: Int, testSamplesCode: String): LLMProcessManager {
         val classesToTest = mutableListOf<PsiClass>()
 
         ApplicationManager.getApplication().runReadAction(

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/error/LLMErrorManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/error/LLMErrorManager.kt
@@ -21,8 +21,6 @@ import org.jetbrains.research.testspark.tools.template.error.ErrorManager
  * This class is part of the LLMErrorManager module.
  */
 class LLMErrorManager : ErrorManager {
-
-
     /**
      * Represents a private logger instance for logging messages within the class.
      *

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/error/LLMErrorManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/error/LLMErrorManager.kt
@@ -2,6 +2,7 @@ package org.jetbrains.research.testspark.tools.llm.error
 
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
@@ -20,6 +21,15 @@ import org.jetbrains.research.testspark.tools.template.error.ErrorManager
  * This class is part of the LLMErrorManager module.
  */
 class LLMErrorManager : ErrorManager {
+
+
+    /**
+     * Represents a private logger instance for logging messages within the class.
+     *
+     * @property log The instance of the logger.
+     */
+    private val log = Logger.getInstance(this::class.java)
+
     /**
      * Creates an error message for a request.
      *
@@ -36,6 +46,7 @@ class LLMErrorManager : ErrorManager {
      */
     override fun errorProcess(message: String, project: Project, errorMonitor: ErrorMonitor) {
         if (errorMonitor.notifyErrorOccurrence()) {
+            log.warn("Error in Test Generation: $message")
             NotificationGroupManager.getInstance()
                 .getNotificationGroup("LLM Execution Error")
                 .createNotification(
@@ -54,6 +65,7 @@ class LLMErrorManager : ErrorManager {
      * @param project The project in which to display the notification.
      */
     override fun warningProcess(message: String, project: Project) {
+        log.warn("Error in Test Generation: $message")
         NotificationGroupManager.getInstance()
             .getNotificationGroup("LLM Execution Error")
             .createNotification(

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/error/LLMErrorManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/error/LLMErrorManager.kt
@@ -21,11 +21,6 @@ import org.jetbrains.research.testspark.tools.template.error.ErrorManager
  * This class is part of the LLMErrorManager module.
  */
 class LLMErrorManager : ErrorManager {
-    /**
-     * Represents a private logger instance for logging messages within the class.
-     *
-     * @property log The instance of the logger.
-     */
     private val log = Logger.getInstance(this::class.java)
 
     /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -148,6 +148,11 @@
     <depends>com.intellij.modules.java</depends>
 
     <extensions defaultExtensionNs="com.intellij">
+        <appStarter
+                implementation="org.jetbrains.research.testspark.appstarter.TestSparkStarter"
+                id="testspark"
+        />
+
         <toolWindow id="TestSpark" secondary="true" anchor="right" icon="org.jetbrains.research.testspark.display.TestSparkIcons.toolWindowIcon"
                     factoryClass="org.jetbrains.research.testspark.toolwindow.TestSparkToolWindowFactory"/>
 


### PR DESCRIPTION
# Description of changes made
I have added Headless mode to the plugin. In this mode, the test generation can be executed from CLI.
We now have a new class called `TestSparkStarter,` which its main method performs the test generation according to given arguments. I have also prepared a [bash file](https://github.com/JetBrains-Research/TestSpark/blob/pderakhshanfar/improvements/headless/runTestSparkHeadless.sh) for running this gradle task. 
I also implemented a headless indicator, which mocks the whole IDE indicator during the test generation process.

# Why is merge request needed
This is required for running the offline evaluations of LLM-based test generation

# Other notes
Closes [ICTL-862](https://youtrack.jetbrains.com/issue/ICTL-862) Running TestSpark in headless mode

# What is missing?
Currently, it supports LLm-based test generation using JetBrains AI Assistant. We might need to do the same for other types of test generators.

- [x] I have checked that I am merging into correct branch
