### PR TITLE
Remove Java Stream API use in CoverageVisualisationService

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/services/CoverageVisualisationService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/CoverageVisualisationService.kt
@@ -83,7 +83,7 @@ class CoverageVisualisationService(private val project: Project) {
 
         updateCoverage(
             testReport.allCoveredLines,
-            testReport.testCaseList.values.stream().map { it.id }.toList().toHashSet(),
+            testReport.testCaseList.values.map { it.id }.toHashSet(),
             testReport,
         )
     }


### PR DESCRIPTION
# Description of changes made
The original version of `CoverageVisualisationService` uses Java Stream API. It has two problems:

1. It does not give any particular performance improvements and just makes code mode complicated.
2. It uses Java 16 API with `Stream.toList()` method, which prevents TestSpark being compiled on lower versions of JDK.

# Why is merge request needed

This fix allows TestSpark to be build on JDK 11 and lower

# Other notes


# What is missing?

- [x] I have checked that I am merging into correct branch
