### PR TITLE
Fix the Null SDK issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -382,6 +382,13 @@ tasks.register<Copy>("copyJUnitRunnerLib") {
 }
 
 /**
+ * Returns the original string if it is not null, or the default string if the original string is null.
+ *
+ * @param default the default string to return if the original string is null
+ * @return the original string if it is not null, or the default string if the original string is null
+ */
+fun String?.orDefault(default: String): String = this ?: default
+/**
  * This code sets up a Gradle task for running the plugin in headless mode
  *
  * @param root The root directory of the project under test.
@@ -392,6 +399,7 @@ tasks.register<Copy>("copyJUnitRunnerLib") {
  * @param token The token for using LLM.
  * @param prompt a txt file containing the LLM's prompt template
  * @param out The output directory for the project.
+ * @param javahome the home directory of Project's SDK for compiling and running tests
  */
 tasks.create<RunIdeTask>("headless") {
     val root: String? by project
@@ -403,8 +411,9 @@ tasks.create<RunIdeTask>("headless") {
     val token: String? by project
     val prompt: String? by project
     val out: String? by project
+    val javahome: String? by project
 
-    args = listOfNotNull("testspark", root, file, cut, cp, junitv, llm, token, prompt, out)
+    args = listOfNotNull("testspark", root, file, cut, cp, junitv.orDefault("4"), llm, token, prompt, out, javahome.orDefault(""))
 
     jvmArgs(
         "-Xmx16G",

--- a/runTestSparkHeadless.sh
+++ b/runTestSparkHeadless.sh
@@ -21,10 +21,11 @@ if [ $# -ne "11" ]; then
         7) Grazie token
         8) Filepath to a txt-file containing prompt template
         9) Output directory
-        10) Space username
-        11) Space password"
+        10) Java home directory
+        11) Space username
+        12) Space password"
   exit 1
 fi
 
 
-"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pjunitv="$5" -Pllm="$6" -Ptoken="$7" -Pprompt="$8" -Pout="$9" -Dspace.username="${10}" -Dspace.pass="${11}"
+"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pjunitv="$5" -Pllm="$6" -Ptoken="$7" -Pprompt="$8" -Pout="$9" javahome=${10} -Dspace.username="${11}" -Dspace.pass="${12}"

--- a/runTestSparkHeadless.sh
+++ b/runTestSparkHeadless.sh
@@ -28,4 +28,4 @@ if [ $# -ne "12" ]; then
 fi
 
 
-"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pjunitv="$5" -Pllm="$6" -Ptoken="$7" -Pprompt="$8" -Pout="$9" javahome=${10} -Dspace.username="${11}" -Dspace.pass="${12}"
+"$DIR/gradlew" -p "$DIR" headless -Proot="$1" -Pfile="$2" -Pcut="$3" -Pcp="$4" -Pjunitv="$5" -Pllm="$6" -Ptoken="$7" -Pprompt="$8" -Pout="$9" -Pjavahome="${10}" -Dspace.username="${11}" -Dspace.pass="${12}"

--- a/runTestSparkHeadless.sh
+++ b/runTestSparkHeadless.sh
@@ -10,7 +10,7 @@ echo $DIR
 
 echo "Provided arguments are $@"
 
-if [ $# -ne "11" ]; then
+if [ $# -ne "12" ]; then
   echo "$# arguments provided, expected 11 arguments in the following order:
         1) Path to the root directory of the project under test (ProjectPath)
         2) Path to the target file (.java file) (it MUST be relative to the ProjectPath)

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestCompilerFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestCompilerFactory.kt
@@ -7,8 +7,12 @@ import org.jetbrains.research.testspark.core.test.TestCompiler
 
 class TestCompilerFactory {
     companion object {
-        fun createJavacTestCompiler(project: Project, junitVersion: JUnitVersion): TestCompiler {
-            val javaHomePath = ProjectRootManager.getInstance(project).projectSdk!!.homeDirectory!!.path
+        fun createJavacTestCompiler(
+            project: Project,
+            junitVersion: JUnitVersion,
+            javaHomeDirectory: String? = null
+        ): TestCompiler {
+            val javaHomePath = javaHomeDirectory ?: ProjectRootManager.getInstance(project).projectSdk!!.homeDirectory!!.path
             val libraryPaths = LibraryPathsProvider.getTestCompilationLibraryPaths()
             val junitLibraryPaths = LibraryPathsProvider.getJUnitLibraryPaths(junitVersion)
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -3,6 +3,7 @@ package org.jetbrains.research.testspark.tools.llm
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.projectRoots.Sdk
 import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.data.CodeType
@@ -36,6 +37,7 @@ class Llm(override val name: String = "LLM") : Tool {
         psiHelper: PsiHelper,
         caretOffset: Int,
         testSamplesCode: String,
+        projectSDK: Sdk? = null
     ): LLMProcessManager {
         val classesToTest = mutableListOf<PsiClassWrapper>()
 
@@ -49,6 +51,7 @@ class Llm(override val name: String = "LLM") : Tool {
             project,
             PromptManager(project, psiHelper, caretOffset),
             testSamplesCode,
+            projectSDK
         )
     }
 


### PR DESCRIPTION
# Description of changes made
Users can now see their own SDK for project under test in the headless mode. If this SDK is not provided and IJ cannot also detected a project SDK for this project, the script uses the SDK provided in Java home. 

# Why is merge request needed
Headless mode does not work properly and it throws null pointer exception because of null sdk

# Other notes
Closes #*issue_number*


- [x] I have checked that I am merging into correct branch
