### PR TITLE
Introduce chat-role-sealed classes for `ChatMessage`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/ChatMessage.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/ChatMessage.kt
@@ -1,6 +1,15 @@
 package org.jetbrains.research.testspark.core.data
 
-data class ChatMessage(
-    val role: String,
+
+open class ChatMessage protected constructor(
+    val role: ChatRole,
     val content: String,
-)
+) {
+    enum class ChatRole(val representation: String) {
+        User("user"),
+        Assistant("assistant"),
+    }
+}
+
+class ChatUserMessage(content: String) : ChatMessage(ChatRole.User, content)
+class ChatAssistantMessage(content: String) : ChatMessage(ChatRole.Assistant, content)

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/ChatMessage.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/ChatMessage.kt
@@ -4,9 +4,9 @@ open class ChatMessage protected constructor(
     val role: ChatRole,
     val content: String,
 ) {
-    enum class ChatRole(val representation: String) {
-        User("user"),
-        Assistant("assistant"),
+    enum class ChatRole {
+        User,
+        Assistant,
     }
 }
 

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/ChatMessage.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/ChatMessage.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.research.testspark.core.data
 
-
 open class ChatMessage protected constructor(
     val role: ChatRole,
     val content: String,

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/network/RequestManager.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/network/RequestManager.kt
@@ -99,7 +99,7 @@ abstract class RequestManager(var token: String) {
 
         log.info { "The full response: \n $response" }
 
-        // check if response is empty
+        // check if the response is empty
         if (response.isEmpty() || response.isBlank()) {
             return LLMResponse(ResponseErrorCode.EMPTY_LLM_RESPONSE, null)
         }

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/network/RequestManager.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/network/RequestManager.kt
@@ -1,7 +1,9 @@
 package org.jetbrains.research.testspark.core.generation.llm.network
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.research.testspark.core.data.ChatAssistantMessage
 import org.jetbrains.research.testspark.core.data.ChatMessage
+import org.jetbrains.research.testspark.core.data.ChatUserMessage
 import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
@@ -36,8 +38,7 @@ abstract class RequestManager(var token: String) {
         errorMonitor: ErrorMonitor = DefaultErrorMonitor(), // The plugin for other IDEs can send LLM requests without passing an errorMonitor
     ): LLMResponse {
         // save the prompt in chat history
-        // TODO: make role to be an enum class
-        chatHistory.add(ChatMessage("user", prompt))
+        chatHistory.add(ChatUserMessage(prompt))
 
         // Send Request to LLM
         log.info { "Sending Request..." }
@@ -67,9 +68,9 @@ abstract class RequestManager(var token: String) {
         val response = testsAssembler.getContent()
 
         log.info { "The full response: \n $response" }
-        chatHistory.add(ChatMessage("assistant", response))
+        chatHistory.add(ChatAssistantMessage(response))
 
-        // check if response is empty
+        // check if the response is empty
         if (response.isEmpty() || response.isBlank()) {
             return LLMResponse(ResponseErrorCode.EMPTY_LLM_RESPONSE, null)
         }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
@@ -2,6 +2,7 @@ package org.jetbrains.research.testspark.tools.llm.generation.grazie
 
 import com.intellij.openapi.project.Project
 import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
+import org.jetbrains.research.testspark.core.data.ChatMessage
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.core.test.TestsAssembler
@@ -63,7 +64,11 @@ class GrazieRequestManager(project: Project) : IJRequestManager(project) {
     private fun getMessages(): List<Pair<String, String>> {
         val result = mutableListOf<Pair<String, String>>()
         chatHistory.forEach {
-            result.add(Pair(it.role.representation, it.content))
+            val role = when(it.role) {
+                ChatMessage.ChatRole.User -> "user"
+                ChatMessage.ChatRole.Assistant -> "assistant"
+            }
+            result.add(Pair(role, it.content))
         }
         return result
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
@@ -63,7 +63,7 @@ class GrazieRequestManager(project: Project) : IJRequestManager(project) {
     private fun getMessages(): List<Pair<String, String>> {
         val result = mutableListOf<Pair<String, String>>()
         chatHistory.forEach {
-            result.add(Pair(it.role, it.content))
+            result.add(Pair(it.role.representation, it.content))
         }
         return result
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
@@ -64,7 +64,7 @@ class GrazieRequestManager(project: Project) : IJRequestManager(project) {
     private fun getMessages(): List<Pair<String, String>> {
         val result = mutableListOf<Pair<String, String>>()
         chatHistory.forEach {
-            val role = when(it.role) {
+            val role = when (it.role) {
                 ChatMessage.ChatRole.User -> "user"
                 ChatMessage.ChatRole.Assistant -> "assistant"
             }


### PR DESCRIPTION
# Description of changes made
Change the API of `ChatMessage` and the way client code uses it to define chat messages and message roles. 

# Why is merge request needed
Previously, a chat role was defined as `"user"` and `"assistant"`, which is not a robust solution. The current implementation makes it harder to make a mistake in a chat message role definition and simplifies the API for client code, allowing the use of only 2 chat message classes, namely `ChatUserMessage`, and `ChatAssistantMessage`.

# Other notes
Closes #261 

- [x] I have checked that I am merging into the correct branch
