### PR TITLE
Move the HTTP request parsing into OpenAPI request manager

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
@@ -1,10 +1,7 @@
 package org.jetbrains.research.testspark.tools.llm.generation
 
-import com.google.gson.Gson
-import com.google.gson.JsonParser
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
-import com.intellij.util.io.HttpRequests
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.core.data.JUnitVersion
 import org.jetbrains.research.testspark.core.data.TestGenerationData
@@ -15,8 +12,6 @@ import org.jetbrains.research.testspark.core.test.parsers.TestSuiteParser
 import org.jetbrains.research.testspark.core.test.parsers.java.JUnitTestSuiteParser
 import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.settings.llm.LLMSettingsState
-import org.jetbrains.research.testspark.tools.ToolUtils
-import org.jetbrains.research.testspark.tools.llm.generation.openai.OpenAIChoice
 
 /**
  * Assembler class for generating and organizing test cases.

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
@@ -51,40 +51,6 @@ class JUnitTestsAssembler(
         updateProgressBar()
     }
 
-    /**
-     * Receives a response text and updates the progress bar accordingly.
-     *
-     * @param httpRequest the httpRequest sent to OpenAI
-     */
-    fun consume(httpRequest: HttpRequests.Request) {
-        while (true) {
-            if (ToolUtils.isProcessCanceled(indicator)) return
-
-            Thread.sleep(50L)
-            var text = httpRequest.reader.readLine()
-
-            if (text.isEmpty()) continue
-
-            text = text.removePrefix("data: ")
-
-            val choices =
-                Gson().fromJson(
-                    JsonParser.parseString(text)
-                        .asJsonObject["choices"]
-                        .asJsonArray[0].asJsonObject,
-                    OpenAIChoice::class.java,
-                )
-
-            if (choices.finishedReason == "stop") break
-
-            // Collect the response and update the progress bar
-            super.consume(choices.delta.content)
-            updateProgressBar()
-        }
-
-        log.debug(super.getContent())
-    }
-
     private fun updateProgressBar() {
         val generatedTestsCount = super.getContent().split("@Test").size - 1
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/openai/OpenAIRequestManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/openai/OpenAIRequestManager.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.research.testspark.tools.llm.generation.openai
 
+import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.JsonParser
 import com.intellij.openapi.project.Project
 import com.intellij.util.io.HttpRequests
 import com.intellij.util.io.HttpRequests.HttpStatusException
@@ -8,6 +10,7 @@ import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.core.test.TestsAssembler
+import org.jetbrains.research.testspark.tools.ToolUtils
 import org.jetbrains.research.testspark.tools.llm.SettingsArguments
 import org.jetbrains.research.testspark.tools.llm.error.LLMErrorManager
 import org.jetbrains.research.testspark.tools.llm.generation.IJRequestManager
@@ -43,7 +46,13 @@ class OpenAIRequestManager(project: Project) : IJRequestManager(project) {
 
                 // check response
                 when (val responseCode = (it.connection as HttpURLConnection).responseCode) {
-                    HttpURLConnection.HTTP_OK -> (testsAssembler as JUnitTestsAssembler).consume(it)
+                    HttpURLConnection.HTTP_OK -> {
+                        assembleLlmResponse(
+                            httpRequest = it,
+                            indicator,
+                            testsAssembler,
+                        )
+                    }
                     HttpURLConnection.HTTP_INTERNAL_ERROR -> {
                         llmErrorManager.errorProcess(
                             LLMMessagesBundle.get("serverProblems"),
@@ -85,5 +94,43 @@ class OpenAIRequestManager(project: Project) : IJRequestManager(project) {
         }
 
         return sendResult
+    }
+
+    /**
+     * Receives the LLM's response text and feeds it to the provided `TestsAssembler`.
+     *
+     * @param httpRequest the httpRequest sent to OpenAI
+     * @param testsAssembler the test assembler to which the response is fed
+     */
+    private fun assembleLlmResponse(
+        httpRequest: HttpRequests.Request,
+        indicator: CustomProgressIndicator,
+        testsAssembler: TestsAssembler,
+    ) {
+        while (true) {
+            if (ToolUtils.isProcessCanceled(indicator)) return
+
+            Thread.sleep(50L)
+            var text = httpRequest.reader.readLine()
+
+            if (text.isEmpty()) continue
+
+            text = text.removePrefix("data: ")
+
+            val choices =
+                Gson().fromJson(
+                    JsonParser.parseString(text)
+                        .asJsonObject["choices"]
+                        .asJsonArray[0].asJsonObject,
+                    OpenAIChoice::class.java,
+                )
+
+            if (choices.finishedReason == "stop") break
+
+            // Feed the response to the assembler
+            testsAssembler.consume(choices.delta.content)
+        }
+
+        log.debug { testsAssembler.getContent() }
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/openai/OpenAIRequestManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/openai/OpenAIRequestManager.kt
@@ -99,6 +99,7 @@ class OpenAIRequestManager(project: Project) : IJRequestManager(project) {
      * Receives the LLM's response text and feeds it to the provided `TestsAssembler`.
      *
      * @param httpRequest the httpRequest sent to OpenAI
+     * @param indicator UI indicator that it checked for cancellation while parsing the LLM's response
      * @param testsAssembler the test assembler to which the response is fed
      */
     private fun assembleLlmResponse(

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/openai/OpenAIRequestManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/openai/OpenAIRequestManager.kt
@@ -14,7 +14,6 @@ import org.jetbrains.research.testspark.tools.ToolUtils
 import org.jetbrains.research.testspark.tools.llm.SettingsArguments
 import org.jetbrains.research.testspark.tools.llm.error.LLMErrorManager
 import org.jetbrains.research.testspark.tools.llm.generation.IJRequestManager
-import org.jetbrains.research.testspark.tools.llm.generation.JUnitTestsAssembler
 import java.net.HttpURLConnection
 
 /**


### PR DESCRIPTION
# Description of changes made
Remove the exposure of network details and OpenAI's response structure from the `JUnitTestsAssebler`. 

# Why is merge request needed
It makes the `JUnitTestsAssebler` complement the Single Responsibility Principle of OOP.

# Other notes
Closes #269 

# What is missing?
**I CANNOT test the refactoring as I do not have the OpenAI API token.** 

- [x] I have checked that I am merging into correct branch.
