### PR TITLE
Fix typo in the plugin description page: to -> two

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/toolwindow/DescriptionTab.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/toolwindow/DescriptionTab.kt
@@ -181,7 +181,7 @@ class DescriptionTab(private val project: Project) {
             "Welcome and thank you for using TestSpark!<br>" +
             "This plugin let you to generate tests for Java classes, method, and single lines.<br>" +
             "TestSpark is currently developed and maintained by <a href=https://lp.jetbrains.com/research/ictl/>ICTL at JetBrains Research</a>.<br>" +
-            "We are currently supporting to types of test generation:<br><br></font></body></html>"
+            "We are currently supporting two types of test generation:<br><br></font></body></html>"
     }
 
     /**


### PR DESCRIPTION
# Description of changes made
Fix a typo in the description page of the plugin.

# Why is merge request needed
It fixes the typo.

# Other notes
Closes #222 

- [x] I have checked that I am merging into correct branch
