### PR TITLE
[#311] Adding a stub for a problem with `kotlinc`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -12,6 +12,7 @@ class KotlinTestCompiler(libPaths: List<String>, junitLibPaths: List<String>) :
     override fun compileCode(path: String, projectBuildPath: String): Pair<Boolean, String> {
         log.info { "[KotlinTestCompiler] Compiling ${path.substringAfterLast('/')}" }
 
+        // TODO find the kotlinc if it is not in PATH
         val classPaths = "\"${getClassPaths(projectBuildPath)}\""
         // Compile file
         val errorMsg = CommandLineRunner.run(
@@ -23,7 +24,13 @@ class KotlinTestCompiler(libPaths: List<String>, junitLibPaths: List<String>) :
             ),
         )
 
-        log.info { "Error message: '$errorMsg'" }
+        if (errorMsg.isNotEmpty()) {
+            log.info { "Error message: '$errorMsg'" }
+            if (errorMsg.contains("kotlinc: command not found'")) {
+                throw RuntimeException(errorMsg)
+            }
+        }
+
 
         // No need to save the .class file for kotlin, so checking the error message is enough
         return Pair(errorMsg.isBlank(), errorMsg)

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -31,7 +31,6 @@ class KotlinTestCompiler(libPaths: List<String>, junitLibPaths: List<String>) :
             }
         }
 
-
         // No need to save the .class file for kotlin, so checking the error message is enough
         return Pair(errorMsg.isBlank(), errorMsg)
     }


### PR DESCRIPTION
# Description of changes made

The description of the bug is in the issue #311. The current PR does not fix the problem with finding kotlin compiler for only in the PATH, but adds a proper error for easier understanding of an actual problem behind failure.

- [x] I have checked that I am merging into correct branch
