### PR TITLE
Use Psi based Internal Representation of generated tests

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/TestGenerationData.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/TestGenerationData.kt
@@ -2,7 +2,7 @@ package org.jetbrains.research.testspark.core.data
 
 import org.jetbrains.research.testspark.core.test.data.TestCaseGeneratedByLLM
 
-data class TestGenerationData(
+open class TestGenerationData(
     // Result processing
     // Report object for each test case
     var testGenerationResultList: MutableList<Report?> = mutableListOf(),

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -16,11 +16,11 @@ import com.intellij.psi.PsiManager
 import kotlinx.serialization.ExperimentalSerializationApi
 import org.jetbrains.research.testspark.bundles.llm.LLMDefaultsBundle
 import org.jetbrains.research.testspark.core.data.JUnitVersion
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
 import org.jetbrains.research.testspark.core.test.TestCompiler
 import org.jetbrains.research.testspark.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.data.ProjectContext
 import org.jetbrains.research.testspark.data.llm.JsonEncoding
 import org.jetbrains.research.testspark.langwrappers.PsiHelperProvider
@@ -145,10 +145,9 @@ class TestSparkStarter : ApplicationStarter {
                             cutModule,
                         )
                         // Prepare the test generation data
-                        val testGenerationData = TestGenerationData(
-                            resultPath = output,
-                            testResultName = "HeadlessGeneratedTests",
-                        )
+                        val testGenerationData = IJTestGenerationData.nullInitializer()
+                        testGenerationData.resultPath = output
+                        testGenerationData.testResultName = "HeadlessGeneratedTests"
                         println("[TestSpark Starter] Indexing is done")
 
                         // get package name

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -185,6 +185,7 @@ class TestSparkStarter : ApplicationStarter {
                             FragmentToTestData(CodeType.CLASS),
                             packageName,
                             projectContext,
+                            project,
                             testGenerationData,
                             errorMonitor,
                         )

--- a/src/main/kotlin/org/jetbrains/research/testspark/data/IJTestGenerationData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/data/IJTestGenerationData.kt
@@ -1,14 +1,17 @@
 package org.jetbrains.research.testspark.data
 
-import com.intellij.lang.Language
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
-import com.intellij.psi.*
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiImportStatement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiPackageStatement
 import com.intellij.psi.util.PsiTreeUtil
-import com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.research.testspark.core.data.TestGenerationData
 import java.io.File
 
@@ -22,10 +25,10 @@ class IJTestGenerationData(
     val testMethods: List<PsiMethod>,
     val helperMethods: List<PsiMethod>,
     val helperFields: List<PsiField>,
-    //TODO may need to add static initializers for kex
+    // TODO may need to add static initializers for kex
     testGenerationData: TestGenerationData,
 
-    ) : TestGenerationData(
+) : TestGenerationData(
     testGenerationData.testGenerationResultList,
     testGenerationData.resultName,
     testGenerationData.fileUrl,
@@ -38,7 +41,7 @@ class IJTestGenerationData(
     testGenerationData.otherInfo,
     testGenerationData.polyDepthReducing,
     testGenerationData.inputParamsDepthReducing,
-    testGenerationData.compilableTestCases
+    testGenerationData.compilableTestCases,
 ) {
     companion object {
         /**
@@ -50,9 +53,9 @@ class IJTestGenerationData(
         fun buildFromCodeString(
             code: String,
             testGenerationData: TestGenerationData,
-            project: Project
+            project: Project,
         ): IJTestGenerationData {
-            //TODO set filetype according to the language
+            // TODO set filetype according to the language
             val psiFile = project.createPsiFile(code, "GeneratedTests.java")
             return ApplicationManager.getApplication().runReadAction<IJTestGenerationData> {
                 val (testMethods, helperMethods) = psiFile.partitionMethods()
@@ -75,6 +78,7 @@ class IJTestGenerationData(
             return PsiTreeUtil.findChildrenOfType(this, PsiMethod::class.java)
                 .partition { method -> method.annotations.any { it.text.contains("Test") } }
         }
+
         /**
          * Creates a PsiFile from a given string content.
          *
@@ -91,7 +95,7 @@ class IJTestGenerationData(
             val virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(tempFile)!!
             val (document, psiFile) = ApplicationManager.getApplication().runReadAction<Pair<Document, PsiFile>> {
                 FileDocumentManager.getInstance().getDocument(virtualFile)!! to
-                        PsiManager.getInstance(this).findFile(virtualFile)!!
+                    PsiManager.getInstance(this).findFile(virtualFile)!!
             }
             ApplicationManager.getApplication().invokeAndWait {
                 FileDocumentManager.getInstance().saveDocument(document)
@@ -99,7 +103,7 @@ class IJTestGenerationData(
             return psiFile
         }
 
-        //TODO remove after the planned separation of the IR and metadata (file names and paths) in IJTestGenerationData
+        // TODO remove after the planned separation of the IR and metadata (file names and paths) in IJTestGenerationData
         fun nullInitializer(): IJTestGenerationData {
             return IJTestGenerationData(null, listOf(), listOf(), listOf(), listOf(), TestGenerationData())
         }

--- a/src/main/kotlin/org/jetbrains/research/testspark/data/IJTestGenerationData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/data/IJTestGenerationData.kt
@@ -98,5 +98,10 @@ class IJTestGenerationData(
             }
             return psiFile
         }
+
+        //TODO remove after the planned separation of the IR and metadata (file names and paths) in IJTestGenerationData
+        fun nullInitializer(): IJTestGenerationData {
+            return IJTestGenerationData(null, listOf(), listOf(), listOf(), listOf(), TestGenerationData())
+        }
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/data/IJTestGenerationData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/data/IJTestGenerationData.kt
@@ -1,0 +1,90 @@
+package org.jetbrains.research.testspark.data
+
+import com.intellij.lang.Language
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.openapi.project.Project
+import com.intellij.psi.*
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.research.testspark.core.data.TestGenerationData
+
+/**
+ * This will be the PSI based IR eventually. For now make it extend TestGenerationData for small behaviour-preserving refactors
+ */
+class IJTestGenerationData(
+
+    val packageStatement: PsiPackageStatement?,
+    val imports: List<PsiImportStatement>,
+    val testMethods: List<PsiMethod>,
+    val helperMethods: List<PsiMethod>,
+    val helperFields: List<PsiField>,
+    //TODO may need to add static initializers for kex
+    testGenerationData: TestGenerationData,
+
+    ) : TestGenerationData(
+    testGenerationData.testGenerationResultList,
+    testGenerationData.resultName,
+    testGenerationData.fileUrl,
+    testGenerationData.resultPath,
+    testGenerationData.testResultName,
+    testGenerationData.baseDir,
+    testGenerationData.importsCode,
+    testGenerationData.packageName,
+    testGenerationData.runWith,
+    testGenerationData.otherInfo,
+    testGenerationData.polyDepthReducing,
+    testGenerationData.inputParamsDepthReducing,
+    testGenerationData.compilableTestCases
+) {
+    companion object {
+        /**
+         * Factory method
+         * @param code the test code passed as a string, to initialise the Psi fields
+         * @param testGenerationData used to initialise super class fields
+         * @param project for obtaining a Psi file from the code string
+         */
+        fun buildFromCodeString(
+            code: String,
+            testGenerationData: TestGenerationData,
+            project: Project
+        ): IJTestGenerationData {
+            val psiFile = createPsiFileFromString(code, "GeneratedTests.java", project, Language.findInstance(
+                JavaLanguage::class.java))
+            val (testMethods, helperMethods) = psiFile.partitionMethods()
+            return IJTestGenerationData(
+                PsiTreeUtil.findChildOfType(psiFile, PsiPackageStatement::class.java),
+//                PsiTreeUtil.findChildOfType(psiFile, PsiClass::class.java)!!,
+                PsiTreeUtil.findChildrenOfType(psiFile, PsiImportStatement::class.java).toList(),
+                testMethods,
+                helperMethods,
+                PsiTreeUtil.findChildrenOfType(psiFile, PsiField::class.java).toList(),
+                testGenerationData,
+            )
+        }
+
+        /**
+         * Partitioning by methods having @Test annotation
+         * Works for multiple versions of Junit and even if the Junit import doesn't exist in the PSI file
+         */
+        private fun PsiFile.partitionMethods(): Pair<List<PsiMethod>, List<PsiMethod>> {
+            return PsiTreeUtil.findChildrenOfType(this, PsiMethod::class.java)
+                .partition { method -> method.annotations.any { it.text.contains("Test") } }
+        }
+        /**
+         * Creates a PsiFile from a given string content.
+         *
+         * @param content The content to write to the PsiFile.
+         * @param fileName The name of the file (used to determine the file type).
+         * @param project The IntelliJ project context.
+         * @param language The language of the file.
+         * @return The PsiFile with the given content.
+         */
+        private fun createPsiFileFromString(content: String, fileName: String, project: Project, language: Language): PsiFile {
+            // Create a LightVirtualFile with the given content
+            val lightFile = LightVirtualFile(fileName, language, content)
+
+            // Create a PsiFile from the LightVirtualFile
+            return PsiManager.getInstance(project).findFile(lightFile)!!
+        }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/research/testspark/data/UIContext.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/data/UIContext.kt
@@ -1,13 +1,12 @@
 package org.jetbrains.research.testspark.data
 
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.network.RequestManager
 import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 data class UIContext(
     val projectContext: ProjectContext,
-    val testGenerationOutput: TestGenerationData,
+    val testGenerationOutput: IJTestGenerationData,
     var requestManager: RequestManager? = null,
     val errorMonitor: ErrorMonitor = DefaultErrorMonitor(),
 )

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/TestCasePanelFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/TestCasePanelFactory.kt
@@ -557,7 +557,7 @@ class TestCasePanelFactory(
                 testCase.id,
                 testCase.testName,
                 testCase.testCode,
-                uiContext!!.testGenerationOutput.packageName,
+                uiContext!!.testGenerationOutput.packageStatement!!.packageName,
                 uiContext.testGenerationOutput.resultPath,
                 uiContext.projectContext,
                 testCompiler,

--- a/src/main/kotlin/org/jetbrains/research/testspark/helpers/LLMHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/helpers/LLMHelper.kt
@@ -7,13 +7,13 @@ import com.intellij.openapi.ui.ComboBox
 import com.intellij.util.io.HttpRequests
 import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.bundles.llm.LLMSettingsBundle
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.executeTestCaseModificationRequest
 import org.jetbrains.research.testspark.core.generation.llm.network.RequestManager
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.data.TestSuiteGeneratedByLLM
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.settings.llm.LLMSettingsState
 import org.jetbrains.research.testspark.tools.TestBodyPrinterFactory
@@ -253,7 +253,7 @@ object LLMHelper {
         indicator: CustomProgressIndicator,
         requestManager: RequestManager,
         project: Project,
-        testGenerationOutput: TestGenerationData,
+        testGenerationOutput: IJTestGenerationData,
         errorMonitor: ErrorMonitor,
     ): TestSuiteGeneratedByLLM? {
         // Update Token information

--- a/src/main/kotlin/org/jetbrains/research/testspark/helpers/TestClassBuilderHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/helpers/TestClassBuilderHelper.kt
@@ -1,7 +1,7 @@
 package org.jetbrains.research.testspark.helpers
 
 import com.intellij.openapi.project.Project
-import org.jetbrains.research.testspark.core.data.TestGenerationData
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 
 interface TestClassBuilderHelper {
     /**
@@ -19,7 +19,7 @@ interface TestClassBuilderHelper {
         packageString: String,
         runWith: String,
         otherInfo: String,
-        testGenerationData: TestGenerationData,
+        testGenerationData: IJTestGenerationData,
     ): String
 
     /**
@@ -53,5 +53,5 @@ interface TestClassBuilderHelper {
      * @param code The Java code to be formatted.
      * @return The formatted Java code.
      */
-    fun formatCode(project: Project, code: String, generatedTestData: TestGenerationData): String
+    fun formatCode(project: Project, code: String, generatedTestData: IJTestGenerationData): String
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/helpers/java/JavaClassBuilderHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/helpers/java/JavaClassBuilderHelper.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
-import org.jetbrains.research.testspark.core.data.TestGenerationData
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.helpers.TestClassBuilderHelper
 import java.io.File
 
@@ -26,7 +26,7 @@ object JavaClassBuilderHelper : TestClassBuilderHelper {
         packageString: String,
         runWith: String,
         otherInfo: String,
-        testGenerationData: TestGenerationData,
+        testGenerationData: IJTestGenerationData,
     ): String {
         var testFullText = printUpperPart(className, imports, packageString, runWith, otherInfo)
 
@@ -108,7 +108,7 @@ object JavaClassBuilderHelper : TestClassBuilderHelper {
         return className
     }
 
-    override fun formatCode(project: Project, code: String, generatedTestData: TestGenerationData): String {
+    override fun formatCode(project: Project, code: String, generatedTestData: IJTestGenerationData): String {
         var result = ""
         WriteCommandAction.runWriteCommandAction(project) {
             val fileName = generatedTestData.resultPath + File.separatorChar + "Formatted.java"

--- a/src/main/kotlin/org/jetbrains/research/testspark/helpers/kotlin/KotlinClassBuilderHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/helpers/kotlin/KotlinClassBuilderHelper.kt
@@ -8,7 +8,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.jetbrains.kotlin.idea.KotlinLanguage
-import org.jetbrains.research.testspark.core.data.TestGenerationData
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.helpers.TestClassBuilderHelper
 import java.io.File
 
@@ -24,7 +24,7 @@ object KotlinClassBuilderHelper : TestClassBuilderHelper {
         packageString: String,
         runWith: String,
         otherInfo: String,
-        testGenerationData: TestGenerationData,
+        testGenerationData: IJTestGenerationData,
     ): String {
         log.debug("[KotlinClassBuilderHelper] Generate code for $className")
 
@@ -97,7 +97,7 @@ object KotlinClassBuilderHelper : TestClassBuilderHelper {
         return className
     }
 
-    override fun formatCode(project: Project, code: String, generatedTestData: TestGenerationData): String {
+    override fun formatCode(project: Project, code: String, generatedTestData: IJTestGenerationData): String {
         var result = ""
         WriteCommandAction.runWriteCommandAction(project) {
             val fileName = generatedTestData.resultPath + File.separatorChar + "Formatted.kt"

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/java/JavaTestCaseDisplayService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/java/JavaTestCaseDisplayService.kt
@@ -445,14 +445,14 @@ class JavaTestCaseDisplayService(private val project: Project) : TestCaseDisplay
         // insert imports to a code
         PsiDocumentManager.getInstance(project).getDocument(outputFile)!!.insertString(
             outputFile.importList?.startOffset ?: outputFile.packageStatement?.startOffset ?: 0,
-            uiContext!!.testGenerationOutput.imports.joinToString("\n", postfix = "\n\n") {it.text},
+            uiContext!!.testGenerationOutput.imports.joinToString("\n", postfix = "\n\n") { it.text },
         )
 
         // insert package to a code
         outputFile.packageStatement ?: PsiDocumentManager.getInstance(project).getDocument(outputFile)!!
             .insertString(
                 0,
-                uiContext!!.testGenerationOutput.packageStatement?.text ?: ""
+                uiContext!!.testGenerationOutput.packageStatement?.text ?: "",
             )
     }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/java/JavaTestCaseDisplayService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/java/JavaTestCaseDisplayService.kt
@@ -430,27 +430,29 @@ class JavaTestCaseDisplayService(private val project: Project) : TestCaseDisplay
             )
         }
 
-        // insert other info to a code
+        // insert helper methods
         PsiDocumentManager.getInstance(project).getDocument(outputFile)!!.insertString(
             selectedClass.rBrace!!,
-            uiContext!!.testGenerationOutput.otherInfo + "\n",
+            uiContext!!.testGenerationOutput.helperMethods.joinToString(separator = "\n", postfix = "\n") { it.text },
+        )
+
+        // insert fields
+        PsiDocumentManager.getInstance(project).getDocument(outputFile)!!.insertString(
+            selectedClass.rBrace!!,
+            uiContext!!.testGenerationOutput.helperFields.joinToString(separator = "\n", postfix = "\n") { it.text },
         )
 
         // insert imports to a code
         PsiDocumentManager.getInstance(project).getDocument(outputFile)!!.insertString(
             outputFile.importList?.startOffset ?: outputFile.packageStatement?.startOffset ?: 0,
-            uiContext!!.testGenerationOutput.importsCode.joinToString("\n") + "\n\n",
+            uiContext!!.testGenerationOutput.imports.joinToString("\n", postfix = "\n\n") {it.text},
         )
 
         // insert package to a code
         outputFile.packageStatement ?: PsiDocumentManager.getInstance(project).getDocument(outputFile)!!
             .insertString(
                 0,
-                if (uiContext!!.testGenerationOutput.packageName.isEmpty()) {
-                    ""
-                } else {
-                    "package ${uiContext!!.testGenerationOutput.packageName};\n\n"
-                },
+                uiContext!!.testGenerationOutput.packageStatement?.text ?: ""
             )
     }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/kotlin/KotlinTestCaseDisplayService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/kotlin/KotlinTestCaseDisplayService.kt
@@ -434,14 +434,20 @@ class KotlinTestCaseDisplayService(private val project: Project) : TestCaseDispl
             )
         }
 
-        // insert other info to a code
+        // insert helper methods
         PsiDocumentManager.getInstance(project).getDocument(outputFile)!!.insertString(
             selectedClass.rBrace!!,
-            uiContext!!.testGenerationOutput.otherInfo + "\n",
+            uiContext!!.testGenerationOutput.helperMethods.joinToString(separator = "\n", postfix = "\n") { it.text },
+        )
+
+        // insert fields
+        PsiDocumentManager.getInstance(project).getDocument(outputFile)!!.insertString(
+            selectedClass.rBrace!!,
+            uiContext!!.testGenerationOutput.helperFields.joinToString(separator = "\n", postfix = "\n") { it.text },
         )
 
         // Create the imports string
-        val importsString = uiContext!!.testGenerationOutput.importsCode.joinToString("\n") + "\n\n"
+        val importsString = uiContext!!.testGenerationOutput.imports.joinToString("\n", postfix = "\n\n") {it.text}
 
         // Find the insertion offset
         val insertionOffset = outputFile.importList?.startOffset
@@ -454,8 +460,7 @@ class KotlinTestCaseDisplayService(private val project: Project) : TestCaseDispl
             PsiDocumentManager.getInstance(project).commitDocument(document)
         }
 
-        val packageName = uiContext!!.testGenerationOutput.packageName
-        val packageStatement = if (packageName.isEmpty()) "" else "package $packageName\n\n"
+        val packageStatement = uiContext!!.testGenerationOutput.packageStatement?.text ?: ""
 
         // Insert the package statement at the beginning of the document
         PsiDocumentManager.getInstance(project).getDocument(outputFile)?.let { document ->

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/kotlin/KotlinTestCaseDisplayService.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/kotlin/KotlinTestCaseDisplayService.kt
@@ -447,7 +447,7 @@ class KotlinTestCaseDisplayService(private val project: Project) : TestCaseDispl
         )
 
         // Create the imports string
-        val importsString = uiContext!!.testGenerationOutput.imports.joinToString("\n", postfix = "\n\n") {it.text}
+        val importsString = uiContext!!.testGenerationOutput.imports.joinToString("\n", postfix = "\n\n") { it.text }
 
         // Find the insertion offset
         val insertionOffset = outputFile.importList?.startOffset

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
@@ -97,6 +97,7 @@ class Pipeline(
                             codeType,
                             packageName,
                             projectContext,
+                            project,
                             generatedTestsData,
                             testGenerationController.errorMonitor,
                         )

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
@@ -11,10 +11,10 @@ import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.io.FileUtilRt
 import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.utils.DataFilesUtil
 import org.jetbrains.research.testspark.data.FragmentToTestData
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.data.ProjectContext
 import org.jetbrains.research.testspark.data.UIContext
 import org.jetbrains.research.testspark.display.custom.IJProgressIndicator
@@ -46,7 +46,7 @@ class Pipeline(
     private val testGenerationController: TestGenerationController,
 ) {
     val projectContext: ProjectContext = ProjectContext()
-    val generatedTestsData = TestGenerationData()
+    val generatedTestsData = IJTestGenerationData.nullInitializer()
 
     init {
         val cutPsiClass = psiHelper.getSurroundingClass(caretOffset)!!

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestsAssemblerFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestsAssemblerFactory.kt
@@ -1,16 +1,16 @@
 package org.jetbrains.research.testspark.tools
 
 import org.jetbrains.research.testspark.core.data.JUnitVersion
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.core.test.TestSuiteParser
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.tools.llm.generation.JUnitTestsAssembler
 
 class TestsAssemblerFactory {
     companion object {
         fun createTestsAssembler(
             indicator: CustomProgressIndicator,
-            generationData: TestGenerationData,
+            generationData: IJTestGenerationData,
             testSuiteParser: TestSuiteParser,
             junitVersion: JUnitVersion,
         ) = JUnitTestsAssembler(indicator, generationData, testSuiteParser, junitVersion)

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
@@ -7,13 +7,13 @@ import com.intellij.openapi.roots.CompilerModuleExtension
 import com.intellij.openapi.roots.ModuleRootManager
 import org.jetbrains.research.testspark.core.data.Report
 import org.jetbrains.research.testspark.core.data.TestCase
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.getClassWithTestCaseName
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.utils.DataFilesUtil
 import org.jetbrains.research.testspark.data.IJTestCase
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.helpers.java.JavaClassBuilderHelper
 import org.jetbrains.research.testspark.helpers.kotlin.KotlinClassBuilderHelper
 import org.jetbrains.research.testspark.services.TestsExecutionResultService
@@ -37,7 +37,7 @@ object ToolUtils {
         packageName: String,
         importsCode: MutableSet<String>,
         fileUrl: String,
-        generatedTestData: TestGenerationData,
+        generatedTestData: IJTestGenerationData,
         language: SupportedLanguage = SupportedLanguage.Java,
     ) {
         generatedTestData.fileUrl = fileUrl

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/generation/EvoSuiteProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/generation/EvoSuiteProcessManager.kt
@@ -14,7 +14,6 @@ import org.evosuite.utils.CompactReport
 import org.jetbrains.research.testspark.bundles.evosuite.EvoSuiteDefaultsBundle
 import org.jetbrains.research.testspark.bundles.evosuite.EvoSuiteMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.getImportsCodeFromTestSuiteCode
 import org.jetbrains.research.testspark.core.generation.llm.getPackageFromTestSuiteCode
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
@@ -72,11 +71,10 @@ class EvoSuiteProcessManager(
         packageName: String,
         projectContext: ProjectContext,
         project: Project,
-        generatedTestsData: TestGenerationData,
+        generatedTestsData: IJTestGenerationData,
         errorMonitor: ErrorMonitor,
     ): UIContext? {
-        //TODO remove var usage after the planned separation of the IR and metadata (file names and paths) in IJTestGenerationData
-        var psiGeneratedTestsData: IJTestGenerationData = IJTestGenerationData(null, listOf(), listOf(), listOf(), listOf(), generatedTestsData)
+        var generatedTestsData = generatedTestsData
         try {
             if (ToolUtils.isProcessStopped(errorMonitor, indicator)) return null
 
@@ -208,12 +206,12 @@ class EvoSuiteProcessManager(
                 generatedTestsData,
             )
             // Now additionally create a new IJTestGenerationData object which initializing additional Psi stuff
-            psiGeneratedTestsData = IJTestGenerationData.buildFromCodeString(testGenerationResult.testSuiteCode, generatedTestsData, project)
+            generatedTestsData = IJTestGenerationData.buildFromCodeString(testGenerationResult.testSuiteCode, generatedTestsData, project)
         } catch (e: Exception) {
             evoSuiteErrorManager.errorProcess(EvoSuiteMessagesBundle.get("evosuiteErrorMessage").format(e.message), project, errorMonitor)
             e.printStackTrace()
         }
 
-        return UIContext(projectContext, psiGeneratedTestsData, StandardRequestManagerFactory(project).getRequestManager(project), errorMonitor)
+        return UIContext(projectContext, generatedTestsData, StandardRequestManagerFactory(project).getRequestManager(project), errorMonitor)
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/generation/EvoSuiteProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/generation/EvoSuiteProcessManager.kt
@@ -20,7 +20,12 @@ import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.utils.CommandLineRunner
-import org.jetbrains.research.testspark.data.*
+import org.jetbrains.research.testspark.data.CodeType
+import org.jetbrains.research.testspark.data.FragmentToTestData
+import org.jetbrains.research.testspark.data.IJReport
+import org.jetbrains.research.testspark.data.IJTestGenerationData
+import org.jetbrains.research.testspark.data.ProjectContext
+import org.jetbrains.research.testspark.data.UIContext
 import org.jetbrains.research.testspark.services.EvoSuiteSettingsService
 import org.jetbrains.research.testspark.services.PluginSettingsService
 import org.jetbrains.research.testspark.settings.evosuite.EvoSuiteSettingsState

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
@@ -3,11 +3,11 @@ package org.jetbrains.research.testspark.tools.llm.generation
 import com.intellij.openapi.diagnostic.Logger
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.core.data.JUnitVersion
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.core.test.TestSuiteParser
 import org.jetbrains.research.testspark.core.test.TestsAssembler
 import org.jetbrains.research.testspark.core.test.data.TestSuiteGeneratedByLLM
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 
 /**
  * Assembler class for generating and organizing test cases.
@@ -18,7 +18,7 @@ import org.jetbrains.research.testspark.core.test.data.TestSuiteGeneratedByLLM
  */
 class JUnitTestsAssembler(
     val indicator: CustomProgressIndicator,
-    private val generationData: TestGenerationData,
+    private val generationData: IJTestGenerationData,
     private val testSuiteParser: TestSuiteParser,
     val junitVersion: JUnitVersion,
 ) : TestsAssembler() {

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
@@ -18,10 +18,7 @@ import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.TestsPersistentStorage
 import org.jetbrains.research.testspark.core.test.TestsPresenter
 import org.jetbrains.research.testspark.core.test.data.TestSuiteGeneratedByLLM
-import org.jetbrains.research.testspark.data.FragmentToTestData
-import org.jetbrains.research.testspark.data.IJReport
-import org.jetbrains.research.testspark.data.ProjectContext
-import org.jetbrains.research.testspark.data.UIContext
+import org.jetbrains.research.testspark.data.*
 import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.services.PluginSettingsService
 import org.jetbrains.research.testspark.tools.TestBodyPrinterFactory
@@ -78,6 +75,7 @@ class LLMProcessManager(
         codeType: FragmentToTestData,
         packageName: String,
         projectContext: ProjectContext,
+        project: Project,
         generatedTestsData: TestGenerationData,
         errorMonitor: ErrorMonitor,
     ): UIContext? {
@@ -245,6 +243,9 @@ class LLMProcessManager(
             language,
         )
 
-        return UIContext(projectContext, generatedTestsData, requestManager, errorMonitor)
+
+        val psiGeneratedTestsData = IJTestGenerationData.buildFromCodeString(testSuiteRepresentation!!, generatedTestsData, project)
+
+        return UIContext(projectContext, psiGeneratedTestsData, requestManager, errorMonitor)
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
@@ -6,7 +6,6 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.FeedbackCycleExecutionResult
 import org.jetbrains.research.testspark.core.generation.llm.LLMWithFeedbackCycle
 import org.jetbrains.research.testspark.core.generation.llm.getImportsCodeFromTestSuiteCode
@@ -76,7 +75,7 @@ class LLMProcessManager(
         packageName: String,
         projectContext: ProjectContext,
         project: Project,
-        generatedTestsData: TestGenerationData,
+        generatedTestsData: IJTestGenerationData,
         errorMonitor: ErrorMonitor,
     ): UIContext? {
         log.info("LLM test generation begins")

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
@@ -17,7 +17,11 @@ import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.TestsPersistentStorage
 import org.jetbrains.research.testspark.core.test.TestsPresenter
 import org.jetbrains.research.testspark.core.test.data.TestSuiteGeneratedByLLM
-import org.jetbrains.research.testspark.data.*
+import org.jetbrains.research.testspark.data.FragmentToTestData
+import org.jetbrains.research.testspark.data.IJReport
+import org.jetbrains.research.testspark.data.IJTestGenerationData
+import org.jetbrains.research.testspark.data.ProjectContext
+import org.jetbrains.research.testspark.data.UIContext
 import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.services.PluginSettingsService
 import org.jetbrains.research.testspark.tools.TestBodyPrinterFactory
@@ -241,7 +245,6 @@ class LLMProcessManager(
             generatedTestsData,
             language,
         )
-
 
         val psiGeneratedTestsData = IJTestGenerationData.buildFromCodeString(testSuiteRepresentation!!, generatedTestsData, project)
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/PromptManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/PromptManager.kt
@@ -8,7 +8,6 @@ import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiDocumentManager
 import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.bundles.llm.LLMSettingsBundle
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.prompt.PromptGenerator
 import org.jetbrains.research.testspark.core.generation.llm.prompt.configuration.ClassRepresentation
 import org.jetbrains.research.testspark.core.generation.llm.prompt.configuration.MethodRepresentation
@@ -17,6 +16,7 @@ import org.jetbrains.research.testspark.core.generation.llm.prompt.configuration
 import org.jetbrains.research.testspark.core.generation.llm.prompt.configuration.PromptTemplates
 import org.jetbrains.research.testspark.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.data.llm.JsonEncoding
 import org.jetbrains.research.testspark.langwrappers.PsiClassWrapper
 import org.jetbrains.research.testspark.langwrappers.PsiHelper
@@ -171,12 +171,12 @@ class PromptManager(
         return key to value // mapOf(key to value).entries.first()
     }
 
-    fun isPromptSizeReductionPossible(testGenerationData: TestGenerationData): Boolean {
+    fun isPromptSizeReductionPossible(testGenerationData: IJTestGenerationData): Boolean {
         return (LlmSettingsArguments(project).maxPolyDepth(testGenerationData.polyDepthReducing) > 1) ||
             (LlmSettingsArguments(project).maxInputParamsDepth(testGenerationData.inputParamsDepthReducing) > 1)
     }
 
-    fun reducePromptSize(testGenerationData: TestGenerationData): Boolean {
+    fun reducePromptSize(testGenerationData: IJTestGenerationData): Boolean {
         // reducing depth of polymorphism
         if (LlmSettingsArguments(project).maxPolyDepth(testGenerationData.polyDepthReducing) > 1) {
             testGenerationData.polyDepthReducing++
@@ -196,7 +196,7 @@ class PromptManager(
         return false
     }
 
-    private fun showPromptReductionWarning(testGenerationData: TestGenerationData) {
+    private fun showPromptReductionWarning(testGenerationData: IJTestGenerationData) {
         llmErrorManager.warningProcess(
             LLMMessagesBundle.get("promptReduction") + "\n" +
                 "Maximum depth of polymorphism is ${LlmSettingsArguments(project).maxPolyDepth(testGenerationData.polyDepthReducing)}.\n" +

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/test/JUnitTestSuitePresenter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/test/JUnitTestSuitePresenter.kt
@@ -1,16 +1,16 @@
 package org.jetbrains.research.testspark.tools.llm.test
 
 import com.intellij.openapi.project.Project
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.getClassWithTestCaseName
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.data.TestSuiteGeneratedByLLM
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.helpers.java.JavaClassBuilderHelper
 import org.jetbrains.research.testspark.helpers.kotlin.KotlinClassBuilderHelper
 
 class JUnitTestSuitePresenter(
     private val project: Project,
-    private val generatedTestsData: TestGenerationData,
+    private val generatedTestsData: IJTestGenerationData,
     private val language: SupportedLanguage,
 ) {
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/template/generation/ProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/template/generation/ProcessManager.kt
@@ -1,13 +1,12 @@
 package org.jetbrains.research.testspark.tools.template.generation
 
 import com.intellij.openapi.project.Project
-import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.data.FragmentToTestData
+import org.jetbrains.research.testspark.data.IJTestGenerationData
 import org.jetbrains.research.testspark.data.ProjectContext
 import org.jetbrains.research.testspark.data.UIContext
-import java.io.File
 
 /**
  * An interface representing a process manager.
@@ -26,7 +25,7 @@ interface ProcessManager {
         packageName: String,
         projectContext: ProjectContext,
         project: Project,
-        generatedTestsData: TestGenerationData,
+        generatedTestsData: IJTestGenerationData,
         errorMonitor: ErrorMonitor,
     ): UIContext?
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/template/generation/ProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/template/generation/ProcessManager.kt
@@ -1,11 +1,13 @@
 package org.jetbrains.research.testspark.tools.template.generation
 
+import com.intellij.openapi.project.Project
 import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 import org.jetbrains.research.testspark.data.FragmentToTestData
 import org.jetbrains.research.testspark.data.ProjectContext
 import org.jetbrains.research.testspark.data.UIContext
+import java.io.File
 
 /**
  * An interface representing a process manager.
@@ -23,6 +25,7 @@ interface ProcessManager {
         codeType: FragmentToTestData,
         packageName: String,
         projectContext: ProjectContext,
+        project: Project,
         generatedTestsData: TestGenerationData,
         errorMonitor: ErrorMonitor,
     ): UIContext?


### PR DESCRIPTION
* IJTestGenerationData has Psi members representing the generated code in addition to the string based representation
* An object of this type is initialised at the end of the Pipeline

# Plan of action:
- [ ] Extend `TestGenerationData` (`IJTestGenerationData`) and make a (redundant) representation of code as Psi available from it
- [ ] Use the Psi based representation (Psi fields of `IJTestGenerationData`) making the string based representation redundant
- [ ] Remove the subclass relation and the associated String based fields from `IJTestGenerationData`. Introduce an interface abstracting any remaining commonalities

# Why is merge request needed
Using a Psi based code representation is natural in an intellij project and enables easy access to parsing and code transformations provided by the intellij API.

# Points to consider for reviewers regarding current state of the branch

- It is not clear how much of the reads and writes to the IR needs to be wrapped in read and write locks. This is because `PsiFile`s is not thread-safe.
- It looks like reads to the psi fields of `IJTestGenerationData` do not require locks since they are not directly reading a `PsiFile` (example its a `PsiMethod` instead). However writes always need a lock since the underlying `PsiFile` also needs to be modified

(not important)
- overuse of extension functions?
- have passed an additional parameter, `project: Project`, to `ProcessManager.runTestGenerator`. This could have instead been `scratchPsiFile: PsiFile`

