### PR TITLE
Set fixed size of the requestComboBox

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -117,8 +117,7 @@ class TestCasePanelBuilder(
     )
 
     // Create "Remove" button to remove the test from cache
-    private val removeButton =
-        IconButtonCreator.getButton(TestSparkIcons.remove, PluginLabelsBundle.get("removeTip"))
+    private val removeButton = IconButtonCreator.getButton(TestSparkIcons.remove, PluginLabelsBundle.get("removeTip"))
 
     // Create "Reset" button to reset the changes in the source code of the test
     private val resetButton = IconButtonCreator.getButton(TestSparkIcons.reset, PluginLabelsBundle.get("resetTip"))
@@ -207,14 +206,11 @@ class TestCasePanelBuilder(
                 ),
                 null,
             )
-            NotificationGroupManager.getInstance()
-                .getNotificationGroup("Test case copied")
-                .createNotification(
-                    "",
-                    PluginMessagesBundle.get("testCaseCopied"),
-                    NotificationType.INFORMATION,
-                )
-                .notify(project)
+            NotificationGroupManager.getInstance().getNotificationGroup("Test case copied").createNotification(
+                "",
+                PluginMessagesBundle.get("testCaseCopied"),
+                NotificationType.INFORMATION,
+            ).notify(project)
         }
 
         updateRequestLabel()
@@ -304,6 +300,10 @@ class TestCasePanelBuilder(
 
         sendButton.addActionListener { sendRequest() }
 
+        requestComboBox.preferredSize = Dimension(
+            languageTextField.preferredSize.height - requestJLabel.preferredSize.height - sendButton.preferredSize.height - 20,
+            requestComboBox.preferredSize.height
+        )
         requestComboBox.isEditable = true
 
         return panel
@@ -535,18 +535,17 @@ class TestCasePanelBuilder(
             language,
         )
 
-        val newTestCase = TestProcessor(project)
-            .processNewTestCase(
-                fileName,
-                testCase.id,
-                testCase.testName,
-                testCase.testCode,
-                uiContext!!.testGenerationOutput.packageName,
-                uiContext.testGenerationOutput.resultPath,
-                uiContext.projectContext,
-                testCompiler,
-                testsExecutionResultManager,
-            )
+        val newTestCase = TestProcessor(project).processNewTestCase(
+            fileName,
+            testCase.id,
+            testCase.testName,
+            testCase.testCode,
+            uiContext!!.testGenerationOutput.packageName,
+            uiContext.testGenerationOutput.resultPath,
+            uiContext.projectContext,
+            testCompiler,
+            testsExecutionResultManager,
+        )
 
         testCase.coveredLines = newTestCase.coveredLines
 
@@ -684,7 +683,8 @@ class TestCasePanelBuilder(
      * Updates the current test case with the specified test name and test code.
      */
     private fun updateTestCaseInformation() {
-        testCase.testName = TestAnalyzerFactory.create(language).extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
+        testCase.testName = TestAnalyzerFactory.create(language)
+            .extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
         testCase.testCode = languageTextField.document.text
     }
 


### PR DESCRIPTION
# Description of changes made
When the prompt in the input field under "modify with LLM" gets length, it is impossible to send the request because the input field overflows over the send button.

# Other notes
Closes #313 

- [x] I have checked that I am merging into correct branch
