### PR TITLE
Fix overflow of the input field for prompting an LLM

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -306,6 +306,9 @@ class TestCasePanelBuilder(
 
         sendButton.addActionListener { sendRequest() }
 
+        // Set the preferred size of the requestComboBox.
+        // The width is calculated by subtracting the combined heights of languageTextField, requestJLabel,
+        //     sendButton, and a padding of 20 from languageTextField's preferred height.
         requestComboBox.preferredSize = Dimension(
             languageTextField.preferredSize.height - requestJLabel.preferredSize.height - sendButton.preferredSize.height - 20,
             requestComboBox.preferredSize.height

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -306,13 +306,11 @@ class TestCasePanelBuilder(
 
         sendButton.addActionListener { sendRequest() }
 
-        // Set the preferred size of the requestComboBox.
-        // The width is calculated by subtracting the combined heights of languageTextField, requestJLabel,
-        //     sendButton, and a padding of 20 from languageTextField's preferred height.
-        requestComboBox.preferredSize = Dimension(
-            languageTextField.preferredSize.height - requestJLabel.preferredSize.height - sendButton.preferredSize.height - 20,
-            requestComboBox.preferredSize.height
-        )
+        /**
+         * The following code is a workaround for the issue with the ComboBox preferred size.
+         * See: https://github.com/JetBrains-Research/TestSpark/pull/343/files#r1781430743
+         */
+        requestComboBox.preferredSize = Dimension(0, 0)
         requestComboBox.isEditable = true
 
         return panel

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -119,8 +119,7 @@ class TestCasePanelBuilder(
     )
 
     // Create "Remove" button to remove the test from cache
-    private val removeButton =
-        IconButtonCreator.getButton(TestSparkIcons.remove, PluginLabelsBundle.get("removeTip"))
+    private val removeButton = IconButtonCreator.getButton(TestSparkIcons.remove, PluginLabelsBundle.get("removeTip"))
 
     // Create "Reset" button to reset the changes in the source code of the test
     private val resetButton = IconButtonCreator.getButton(TestSparkIcons.reset, PluginLabelsBundle.get("resetTip"))
@@ -209,14 +208,11 @@ class TestCasePanelBuilder(
                 ),
                 null,
             )
-            NotificationGroupManager.getInstance()
-                .getNotificationGroup("Test case copied")
-                .createNotification(
-                    "",
-                    PluginMessagesBundle.get("testCaseCopied"),
-                    NotificationType.INFORMATION,
-                )
-                .notify(project)
+            NotificationGroupManager.getInstance().getNotificationGroup("Test case copied").createNotification(
+                "",
+                PluginMessagesBundle.get("testCaseCopied"),
+                NotificationType.INFORMATION,
+            ).notify(project)
         }
 
         updateRequestLabel()
@@ -306,6 +302,10 @@ class TestCasePanelBuilder(
 
         sendButton.addActionListener { sendRequest() }
 
+        requestComboBox.preferredSize = Dimension(
+            languageTextField.preferredSize.height - requestJLabel.preferredSize.height - sendButton.preferredSize.height - 20,
+            requestComboBox.preferredSize.height
+        )
         requestComboBox.isEditable = true
 
         return panel
@@ -544,18 +544,17 @@ class TestCasePanelBuilder(
             language,
         )
 
-        val newTestCase = TestProcessor(project)
-            .processNewTestCase(
-                fileName,
-                testCase.id,
-                testCase.testName,
-                testCase.testCode,
-                uiContext!!.testGenerationOutput.packageName,
-                uiContext.testGenerationOutput.resultPath,
-                uiContext.projectContext,
-                testCompiler,
-                testsExecutionResultManager,
-            )
+        val newTestCase = TestProcessor(project).processNewTestCase(
+            fileName,
+            testCase.id,
+            testCase.testName,
+            testCase.testCode,
+            uiContext!!.testGenerationOutput.packageName,
+            uiContext.testGenerationOutput.resultPath,
+            uiContext.projectContext,
+            testCompiler,
+            testsExecutionResultManager,
+        )
 
         testCase.coveredLines = newTestCase.coveredLines
 
@@ -693,7 +692,8 @@ class TestCasePanelBuilder(
      * Updates the current test case with the specified test name and test code.
      */
     private fun updateTestCaseInformation() {
-        testCase.testName = TestAnalyzerFactory.create(language).extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
+        testCase.testName = TestAnalyzerFactory.create(language)
+            .extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
         testCase.testCode = languageTextField.document.text
     }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -308,7 +308,7 @@ class TestCasePanelBuilder(
 
         /**
          * The following code is a workaround for the issue with the ComboBox preferred size.
-         * See: https://github.com/JetBrains-Research/TestSpark/pull/343/files#r1781430743
+         * See: https://github.com/JetBrains-Research/TestSpark/pull/343#discussion_r1781430743
          */
         requestComboBox.preferredSize = Dimension(0, 0)
         requestComboBox.isEditable = true

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -119,7 +119,8 @@ class TestCasePanelBuilder(
     )
 
     // Create "Remove" button to remove the test from cache
-    private val removeButton = IconButtonCreator.getButton(TestSparkIcons.remove, PluginLabelsBundle.get("removeTip"))
+    private val removeButton =
+        IconButtonCreator.getButton(TestSparkIcons.remove, PluginLabelsBundle.get("removeTip"))
 
     // Create "Reset" button to reset the changes in the source code of the test
     private val resetButton = IconButtonCreator.getButton(TestSparkIcons.reset, PluginLabelsBundle.get("resetTip"))
@@ -208,11 +209,14 @@ class TestCasePanelBuilder(
                 ),
                 null,
             )
-            NotificationGroupManager.getInstance().getNotificationGroup("Test case copied").createNotification(
-                "",
-                PluginMessagesBundle.get("testCaseCopied"),
-                NotificationType.INFORMATION,
-            ).notify(project)
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup("Test case copied")
+                .createNotification(
+                    "",
+                    PluginMessagesBundle.get("testCaseCopied"),
+                    NotificationType.INFORMATION,
+                )
+                .notify(project)
         }
 
         updateRequestLabel()
@@ -544,17 +548,18 @@ class TestCasePanelBuilder(
             language,
         )
 
-        val newTestCase = TestProcessor(project).processNewTestCase(
-            fileName,
-            testCase.id,
-            testCase.testName,
-            testCase.testCode,
-            uiContext!!.testGenerationOutput.packageName,
-            uiContext.testGenerationOutput.resultPath,
-            uiContext.projectContext,
-            testCompiler,
-            testsExecutionResultManager,
-        )
+        val newTestCase = TestProcessor(project)
+            .processNewTestCase(
+                fileName,
+                testCase.id,
+                testCase.testName,
+                testCase.testCode,
+                uiContext!!.testGenerationOutput.packageName,
+                uiContext.testGenerationOutput.resultPath,
+                uiContext.projectContext,
+                testCompiler,
+                testsExecutionResultManager,
+            )
 
         testCase.coveredLines = newTestCase.coveredLines
 
@@ -692,8 +697,7 @@ class TestCasePanelBuilder(
      * Updates the current test case with the specified test name and test code.
      */
     private fun updateTestCaseInformation() {
-        testCase.testName = TestAnalyzerFactory.create(language)
-            .extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
+        testCase.testName = TestAnalyzerFactory.create(language).extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
         testCase.testCode = languageTextField.document.text
     }
 


### PR DESCRIPTION
# Description of changes made
When the prompt in the input field under "modify with LLM" gets length, it is impossible to send the request because the input field overflows over the send button.

# Why is merge request needed
*Please write why your merge request is needed*

# Other notes
Closes #313 

- [x] I have checked that I am merging into correct branch
