### PR TITLE
Fix parsing of test cases when test case name starts with `void`/`fun`

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/LLMWithFeedbackCycle.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/LLMWithFeedbackCycle.kt
@@ -193,8 +193,6 @@ class LLMWithFeedbackCycle(
 
             generatedTestSuite = response.testSuite
 
-            println("generatedTestSuite: $generatedTestSuite")
-
             // update imports list
             imports.addAll(generatedTestSuite.imports)
 

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/LLMWithFeedbackCycle.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/generation/llm/LLMWithFeedbackCycle.kt
@@ -45,7 +45,9 @@ data class FeedbackResponse(
         if ((executionResult == FeedbackCycleExecutionResult.OK || executionResult == FeedbackCycleExecutionResult.NO_COMPILABLE_TEST_CASES_GENERATED) &&
             (generatedTestSuite == null)
         ) {
-            throw IllegalArgumentException("Test suite must be provided when FeedbackCycleExecutionResult is OK, got null")
+            throw IllegalArgumentException(
+                "Test suite must be provided when FeedbackCycleExecutionResult is OK or NO_COMPILABLE_TEST_CASES_GENERATED (currently, ${executionResult.name}), got null",
+            )
         }
     }
 }
@@ -190,6 +192,8 @@ class LLMWithFeedbackCycle(
             }
 
             generatedTestSuite = response.testSuite
+
+            println("generatedTestSuite: $generatedTestSuite")
 
             // update imports list
             imports.addAll(generatedTestSuite.imports)

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/strategies/JUnitTestSuiteParserStrategy.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/strategies/JUnitTestSuiteParserStrategy.kt
@@ -109,7 +109,24 @@ class JUnitTestSuiteParserStrategy {
                     errorOccurred = true,
                 )
             }
-            val interestingPartOfSignature = rawTest.split(testNamePattern)[1]
+
+            /**
+             * The test declaration is split into two parts:
+             * [void|fun] <testcase name>() [throws <exception>] { ... }
+             * The first part is the test declaration prologue,
+             * the second part is the test declaration epilogue.
+             *
+             * Therefore, as an epilogue, we have everything after [void|fun].
+             *
+             * `limit = 2` is used to avoid additional splitting in case if the test
+             * case name starts with the same word as the test declaration prologue.
+             */
+            val testCaseEpilogue = rawTest.split(testNamePattern, limit = 2)[1]
+
+            /**
+             * Optional [throws <exception>] part is extracted from the test declaration epilogue.
+             */
+            val interestingPartOfSignature = testCaseEpilogue
                 .split("{")[0]
                 .split("()")[1]
                 .trim()
@@ -119,7 +136,7 @@ class JUnitTestSuiteParserStrategy {
             }
 
             // Get test name
-            val testName: String = rawTest.split(testNamePattern)[1]
+            val testName: String = testCaseEpilogue
                 .split("()")[0]
                 .trim()
 


### PR DESCRIPTION
# Description of changes made
It is a minor modification with an explanation in the Javadoc before the introduced change. See the issue #372 for more details.

# Why is merge request needed
It closes a bug with incorrect parsing of test case names: if a test case starts with `void`/`fun` (Java/Kotlin respectively) then in the implementation the `split` method did two cuts instead of one, which caused the bug.

# Other notes
Closes #372 

- [x] I have checked that I am merging into correct branch.
