### PR TITLE
Locate `kotlinc` filepath via IntelliJ IDEA's bundled Kotlin plugin

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -42,7 +42,7 @@ publishing {
         create<MavenPublication>("maven") {
             groupId = group as String
             artifactId = "testspark-core"
-            version = "4.0.0"
+            version = "5.0.0"
             from(components["java"])
 
             artifact(tasks["sourcesJar"])

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/exception/Exceptions.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/exception/Exceptions.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.research.testspark.core.exception
+
+
+/**
+ * Represents custom exceptions within TestSpark.
+ *
+ * This class serves as a base class for specific exceptions.
+ *
+ * @param message A descriptive message explaining the error that led to the exception.
+ */
+sealed class TestSparkException(message: String) : RuntimeException(message)
+
+/**
+ * Custom exception to indicate that the Kotlin compiler was not found.
+ *
+ * @param message A descriptive message explaining the error.
+ */
+class KotlinCompilerNotFoundException(message: String) : TestSparkException(message)
+
+/**
+ * Custom exception to indicate that the Java compiler was not found.
+ *
+ * @param message A descriptive message explaining the error.
+ */
+class JavaCompilerNotFoundException(message: String) : TestSparkException(message)
+
+/**
+ * Represents an exception thrown when a required Java SDK is missing in the system.
+ *
+ * @param message A descriptive message explaining the specific error that led to this exception.
+ */
+class JavaSDKMissingException(message: String) : TestSparkException(message)

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/exception/Exceptions.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/exception/Exceptions.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.research.testspark.core.exception
 
-
 /**
  * Represents custom exceptions within TestSpark.
  *

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.research.testspark.core.test.java
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.jetbrains.research.testspark.core.exception.JavaCompilerNotFoundException
 import org.jetbrains.research.testspark.core.test.TestCompiler
 import org.jetbrains.research.testspark.core.utils.CommandLineRunner
 import org.jetbrains.research.testspark.core.utils.DataFilesUtil
@@ -29,9 +30,9 @@ class JavaTestCompiler(
             .firstOrNull()
 
         if (javaCompiler == null) {
-            val msg = "Cannot find java compiler 'javac' at '$javaHomeDirectoryPath'"
+            val msg = "Cannot find Java compiler 'javac' at $javaHomeDirectoryPath"
             logger.error { msg }
-            throw RuntimeException(msg)
+            throw JavaCompilerNotFoundException("Ensure Java SDK is configured for the project. $msg.")
         }
         javac = javaCompiler.absolutePath
     }

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -36,7 +36,6 @@ class JavaTestCompiler(
         javac = javaCompiler.absolutePath
     }
 
-
     override fun compileCode(path: String, projectBuildPath: String): Pair<Boolean, String> {
         val classPaths = "\"${getClassPaths(projectBuildPath)}\""
         // compile file

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -16,6 +16,7 @@ class JavaTestCompiler(
 
     override fun compileCode(path: String, projectBuildPath: String): Pair<Boolean, String> {
         val classPaths = "\"${getClassPaths(projectBuildPath)}\""
+        // TODO: no need to search for it every time; memoize it
         // find the proper javac
         val javaCompile = File(javaHomeDirectoryPath).walk()
             .filter {
@@ -30,8 +31,6 @@ class JavaTestCompiler(
             log.error { msg }
             throw RuntimeException(msg)
         }
-
-        println("javac found at '${javaCompile.absolutePath}'")
 
         // compile file
         val errorMsg = CommandLineRunner.run(

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -16,13 +16,23 @@ class KotlinTestCompiler(
 
     // init block to find the kotlinc compiler
     init {
-        // TODO: does it work on Windows?
         // search for a proper kotlinc
         val kotlinCompiler = File(kotlinSDKHomeDirectory).walk()
             .filter {
+                /**
+                 * Tested on Windows 10, IntelliJ IDEA Community Edition 2023.1.4 (2023.1.4.IC-231.9225.26)
+                 *
+                 * Windows' kotlinc requires `java` command to be present in ENV (e.g., present in PATH).
+                 * Otherwise, it won't be able to execute itself.
+                 *
+                 * Missing `java` in PATH does not yield runtime error but is considered
+                 * as failed compilation because `kotlinc` will complain about
+                 * `java` command missing in PATH.
+                 *
+                 * TODO(vartiukhov): find a way to locate `java` on Windows
+                 */
                 val isCompilerName = if (DataFilesUtil.isWindows()) {
-                    // TODO: is it kotlinc.exe?
-                    it.name.equals("kotlinc.exe")
+                    it.name.equals("kotlinc")
                 } else {
                     it.name.equals("kotlinc")
                 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
@@ -110,8 +110,7 @@ class Pipeline(
                         if (ToolUtils.isProcessStopped(testGenerationController.errorMonitor, ijIndicator)) return
 
                         ijIndicator.stop()
-                    }
-                    catch (err: TestSparkException) {
+                    } catch (err: TestSparkException) {
                         LLMErrorManager().errorProcess(err.message!!, project, testGenerationController.errorMonitor)
                     }
                 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
@@ -2,13 +2,13 @@ package org.jetbrains.research.testspark.tools.factories
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import org.jetbrains.kotlin.idea.compiler.configuration.KotlinPluginLayout
 import org.jetbrains.research.testspark.core.data.JUnitVersion
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.TestCompiler
 import org.jetbrains.research.testspark.core.test.java.JavaTestCompiler
 import org.jetbrains.research.testspark.core.test.kotlin.KotlinTestCompiler
 import org.jetbrains.research.testspark.tools.LibraryPathsProvider
-import org.jetbrains.kotlin.idea.compiler.configuration.KotlinPluginLayout
 
 object TestCompilerFactory {
     fun create(
@@ -33,8 +33,8 @@ object TestCompilerFactory {
         junitLibraryPaths: List<String>,
         javaHomeDirectory: String? = null,
     ): JavaTestCompiler {
-        val javaSDKHomePath = javaHomeDirectory ?:
-            ProjectRootManager.getInstance(project).projectSdk?.homeDirectory?.path
+        val javaSDKHomePath = javaHomeDirectory
+            ?: ProjectRootManager.getInstance(project).projectSdk?.homeDirectory?.path
 
         if (javaSDKHomePath == null) {
             throw RuntimeException("Java SDK not configured for the project.")

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
@@ -3,7 +3,9 @@ package org.jetbrains.research.testspark.tools.factories
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import org.jetbrains.kotlin.idea.compiler.configuration.KotlinPluginLayout
+import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.core.data.JUnitVersion
+import org.jetbrains.research.testspark.core.exception.JavaSDKMissingException
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.TestCompiler
 import org.jetbrains.research.testspark.core.test.java.JavaTestCompiler
@@ -37,7 +39,7 @@ object TestCompilerFactory {
             ?: ProjectRootManager.getInstance(project).projectSdk?.homeDirectory?.path
 
         if (javaSDKHomePath == null) {
-            throw RuntimeException("Java SDK not configured for the project.")
+            throw JavaSDKMissingException(LLMMessagesBundle.get("javaSdkNotConfigured"))
         }
 
         return JavaTestCompiler(libraryPaths, junitLibraryPaths, javaSDKHomePath)

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
@@ -8,6 +8,7 @@ import org.jetbrains.research.testspark.core.test.TestCompiler
 import org.jetbrains.research.testspark.core.test.java.JavaTestCompiler
 import org.jetbrains.research.testspark.core.test.kotlin.KotlinTestCompiler
 import org.jetbrains.research.testspark.tools.LibraryPathsProvider
+import org.jetbrains.kotlin.idea.compiler.configuration.KotlinPluginLayout
 
 object TestCompilerFactory {
     fun create(
@@ -16,17 +17,38 @@ object TestCompilerFactory {
         language: SupportedLanguage,
         javaHomeDirectory: String? = null,
     ): TestCompiler {
-        val javaSDKHomePath =
-            javaHomeDirectory ?: ProjectRootManager.getInstance(project).projectSdk?.homeDirectory?.path
-                ?: throw RuntimeException("Java SDK not configured for the project.")
-
         val libraryPaths = LibraryPathsProvider.getTestCompilationLibraryPaths()
         val junitLibraryPaths = LibraryPathsProvider.getJUnitLibraryPaths(junitVersion)
 
         // TODO add the warning window that for Java we always need the javaHomeDirectoryPath
         return when (language) {
-            SupportedLanguage.Java -> JavaTestCompiler(libraryPaths, junitLibraryPaths, javaSDKHomePath)
-            SupportedLanguage.Kotlin -> KotlinTestCompiler(libraryPaths, junitLibraryPaths)
+            SupportedLanguage.Java -> createJavaCompiler(project, libraryPaths, junitLibraryPaths, javaHomeDirectory)
+            SupportedLanguage.Kotlin -> createKotlinCompiler(libraryPaths, junitLibraryPaths)
         }
+    }
+
+    private fun createJavaCompiler(
+        project: Project,
+        libraryPaths: List<String>,
+        junitLibraryPaths: List<String>,
+        javaHomeDirectory: String? = null,
+    ): JavaTestCompiler {
+        val javaSDKHomePath = javaHomeDirectory ?:
+            ProjectRootManager.getInstance(project).projectSdk?.homeDirectory?.path
+
+        if (javaSDKHomePath == null) {
+            throw RuntimeException("Java SDK not configured for the project.")
+        }
+
+        return JavaTestCompiler(libraryPaths, junitLibraryPaths, javaSDKHomePath)
+    }
+
+    private fun createKotlinCompiler(
+        libraryPaths: List<String>,
+        junitLibraryPaths: List<String>,
+    ): KotlinTestCompiler {
+        // kotlinc should be under `[kotlinSDKHomeDirectory]/bin/kotlinc`
+        val kotlinSDKHomeDirectory = KotlinPluginLayout.kotlinc.absolutePath
+        return KotlinTestCompiler(libraryPaths, junitLibraryPaths, kotlinSDKHomeDirectory)
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -228,8 +228,7 @@ class Llm(override val name: String = "LLM") : Tool {
             )
 
             pipeline.runTestGeneration(manager, codeType)
-        }
-        catch (err: TestSparkException) {
+        } catch (err: TestSparkException) {
             testGenerationController.finished()
             LLMErrorManager().errorProcess(err.message!!, project, testGenerationController.errorMonitor)
         }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -149,7 +149,7 @@
     <depends>com.intellij.gradle</depends>
 
     <!--    Plugin depends on the Kotlin support plugin that comes with org.jetbrains.kotlin.
-            This dependency is optional, which means plugin can run even if the Java plugin is not available or not enabled.
+            This dependency is optional, which means plugin can run even if the Kotlin plugin is not available or not enabled.
             This dependency will be loaded only when actually needed.
             Moreover, we specify the configuration file to consider when the dependency is needed. -->
     <depends

--- a/src/main/resources/properties/llm/LLMMessages.properties
+++ b/src/main/resources/properties/llm/LLMMessages.properties
@@ -18,3 +18,4 @@ removeTemplateTitle=Can't Be Removed
 defaultPromptIsNotValidMessage=Default prompt is not valid. Fix it, please.
 defaultPromptIsNotValidTitle=Incorrect Prompt State
 hfServerError=The selected model may need an HF PRO subscription to use!
+javaSdkNotConfigured=Java SDK not configured for the project. Navigate to File -> Project Structure -> Project -> Project SDK and select a Java SDK.


### PR DESCRIPTION
# Description of changes made
Retrieves kotlin compiler (`kotlinc`) via `KotlinPluginLayout` component of `org.jetbrains.kotlin` bundled plugin.

# Why is merge request needed
Closes #311 

*Please write if you have anything to add*

# What is missing?
* [x] Test the solution on Windows (test whether Windows has ~~`kotlinc.exe`~~ (it has `kotlinc`) as a compiler):
     1. In the case of Windows, `kotlinc` requires `java` to be executable (e.g., by being present in `PATH`); otherwise, `kotlinc` will complain about missing `java`.
     2. In other words, Kotlin compilation works on Windows but with a nuance. My Windows machine has an old version of IntelliJ (see comment in a file). Maybe newer versions solve this issue. 

* [ ] Once the PR is reviewed, I will publish a new version of `core` module.

## Self-check
- [x] I have checked that I am merging into the correct branch
