### PR TITLE
Prompt serialization: use Kotlin's `Json` to treat special symbols

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/data/llm/JsonEncoding.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/data/llm/JsonEncoding.kt
@@ -21,26 +21,9 @@ class JsonEncoding {
         /**
          * Encode a list of strings into a string
          */
-        fun encode(values: MutableList<String>): String {
-            var jsonString = Json.encodeToString(
-                ListSerializer(String.serializer()),
-                values,
-            )
-            // These characters are incorrectly stored in json, so the following substitutions are required
-            val replacements = mapOf(
-                "\\n" to "\n",
-                "\\t" to "\t",
-                "\\r" to "\r",
-                "\\\\" to "\\",
-                "\\\"" to "\"",
-                "\\'" to "\'",
-                "\\b" to "\b",
-                "\\f" to "\u000c",
-            )
-            replacements.forEach { (key, value) ->
-                jsonString = jsonString.replace(key, value)
-            }
-            return jsonString
-        }
+        fun encode(values: MutableList<String>): String = Json.encodeToString(
+            ListSerializer(String.serializer()),
+            values,
+        )
     }
 }


### PR DESCRIPTION
# Description of changes made
Fixed the bug in treating special symbols in a prompt serializing. Kotlin serialization process already includes working with such symbols, so extra manipulation with them was causing an error while JSON converting.
- [x] I've tested all special symbols that can go from settings directly to LLM

# Other notes
Closes #271

- [x] I have checked that I am merging into the correct branch
