### PR TITLE
Add ability to restore test case if it was deleted

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -26,6 +26,21 @@ object GenerateTestsTabHelper {
     }
 
     /**
+     * A helper method to remove a test case from the cache and from the UI.
+     *
+     * @param testCaseName the name of the test
+     */
+    fun removeUITestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
+        // Update the number of selected test cases if necessary
+        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+            generatedTestsTabData.testsSelected--
+        }
+
+        // Remove the test panel from the UI
+        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
+    }
+
+    /**
      * Updates the user interface of the tool window.
      *
      * This method updates the UI of the tool window tab by calling the updateUI

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -25,6 +25,9 @@ object GenerateTestsTabHelper {
 
         // Remove the editorTextField
         generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
+
+        // Remove the Panel for
+        generatedTestsTabData.testCaseNameToUndoRemovePanel.remove(testCaseName)
     }
 
     /**
@@ -34,9 +37,7 @@ object GenerateTestsTabHelper {
      */
     fun removeUITestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData): Int {
         // Update the number of selected test cases if necessary
-        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
-            generatedTestsTabData.testsSelected--
-        }
+        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.setSelected(false)
 
         val index: Int =
             generatedTestsTabData.allTestCasePanel.getComponentZOrder(generatedTestsTabData.testCaseNameToPanel[testCaseName])

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -1,7 +1,5 @@
 package org.jetbrains.research.testspark.display.generatedTests
 
-import javax.swing.JPanel
-
 object GenerateTestsTabHelper {
     /**
      * A helper method to remove a test case from the cache and from the UI.
@@ -9,14 +7,6 @@ object GenerateTestsTabHelper {
      * @param testCaseName the name of the test
      */
     fun removeTestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
-        // Update the number of selected test cases if necessary
-        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
-            generatedTestsTabData.testsSelected--
-        }
-
-        // Remove the test panel from the UI
-        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
-
         // Remove the test panel
         generatedTestsTabData.testCaseNameToPanel.remove(testCaseName)
 
@@ -27,7 +17,7 @@ object GenerateTestsTabHelper {
         generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
 
         // Remove the Panel for
-        generatedTestsTabData.testCaseNameToUndoRemovePanel.remove(testCaseName)
+        generatedTestsTabData.testCaseNameToRemovePanel.remove(testCaseName)
     }
 
     /**
@@ -35,17 +25,12 @@ object GenerateTestsTabHelper {
      *
      * @param testCaseName the name of the test
      */
-    fun removeUITestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData): Int {
-        // Update the number of selected test cases if necessary
+    fun removeUITestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
+        // Change test from selected to unselected
         generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.setSelected(false)
-
-        val index: Int =
-            generatedTestsTabData.allTestCasePanel.getComponentZOrder(generatedTestsTabData.testCaseNameToPanel[testCaseName])
 
         // Remove the test panel from the UI
         generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
-
-        return index
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.research.testspark.display.generatedTests
 
+import javax.swing.JPanel
+
 object GenerateTestsTabHelper {
     /**
      * A helper method to remove a test case from the cache and from the UI.
@@ -26,18 +28,23 @@ object GenerateTestsTabHelper {
     }
 
     /**
-     * A helper method to remove a test case from the cache and from the UI.
+     * A helper method to remove a test case from the UI.
      *
      * @param testCaseName the name of the test
      */
-    fun removeUITestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
+    fun removeUITestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData): Int {
         // Update the number of selected test cases if necessary
         if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
             generatedTestsTabData.testsSelected--
         }
 
+        val index: Int =
+            generatedTestsTabData.allTestCasePanel.getComponentZOrder(generatedTestsTabData.testCaseNameToPanel[testCaseName])
+
         // Remove the test panel from the UI
         generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
+
+        return index
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -159,7 +159,6 @@ class GeneratedTestsTabBuilder(
 
             testCasePanelFactories.add(testCasePanelBuilder)
 
-
             testCasePanel.add(Box.createRigidArea(Dimension(12, 0)), BorderLayout.EAST)
 
             // Add panel to parent panel
@@ -170,13 +169,13 @@ class GeneratedTestsTabBuilder(
             val testPanelIndex: Int =
                 generatedTestsTabData.allTestCasePanel.getComponentZOrder(testCasePanel)
 
-            val testCaseUndoRemoveButtonPanel: JPanel = testCasePanelBuilder.getUndoRemovePanel(testCase.testName, testCase.id, testPanelIndex)
+            val testCaseRemovePanel: JPanel = testCasePanelBuilder.getRemovePanel(testPanelIndex)
 
             generatedTestsTabData.testCaseNameToPanel[testCase.testName] = testCasePanel
             generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName] = checkbox
             generatedTestsTabData.testCaseNameToEditorTextField[testCase.testName] =
                 testCasePanelBuilder.getEditorTextField()
-            generatedTestsTabData.testCaseNameToUndoRemovePanel[testCase.testName] = testCaseUndoRemoveButtonPanel
+            generatedTestsTabData.testCaseNameToRemovePanel[testCase.testName] = testCaseRemovePanel
         }
         generatedTestsTabData.testsSelected = generatedTestsTabData.testCaseNameToPanel.size
         generatedTestsTabData.testCasePanelFactories.addAll(testCasePanelFactories)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -167,16 +167,16 @@ class GeneratedTestsTabBuilder(
             generatedTestsTabData.allTestCasePanel.add(testCasePanel)
             addSeparator()
 
-            val testCaseDeleteButtonPanel: JPanel = testCasePanelBuilder.getTestButton()
+            val testPanelIndex: Int =
+                generatedTestsTabData.allTestCasePanel.getComponentZOrder(testCasePanel)
 
-//            generatedTestsTabData.allTestCasePanel.add(testCasePanelBuilder.getTestButton(), BorderLayout.EAST)
-//            addSeparator()
+            val testCaseUndoRemoveButtonPanel: JPanel = testCasePanelBuilder.getUndoRemovePanel(testCase.testName, testPanelIndex)
 
             generatedTestsTabData.testCaseNameToPanel[testCase.testName] = testCasePanel
             generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName] = checkbox
             generatedTestsTabData.testCaseNameToEditorTextField[testCase.testName] =
                 testCasePanelBuilder.getEditorTextField()
-            generatedTestsTabData.testCaseNameToDeleteButton[testCase.testName] = testCaseDeleteButtonPanel
+            generatedTestsTabData.testCaseNameToUndoRemovePanel[testCase.testName] = testCaseUndoRemoveButtonPanel
         }
         generatedTestsTabData.testsSelected = generatedTestsTabData.testCaseNameToPanel.size
         generatedTestsTabData.testCasePanelFactories.addAll(testCasePanelFactories)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -159,11 +159,15 @@ class GeneratedTestsTabBuilder(
 
             testCasePanelFactories.add(testCasePanelBuilder)
 
+
             testCasePanel.add(Box.createRigidArea(Dimension(12, 0)), BorderLayout.EAST)
 
             // Add panel to parent panel
             testCasePanel.maximumSize = Dimension(Short.MAX_VALUE.toInt(), Short.MAX_VALUE.toInt())
             generatedTestsTabData.allTestCasePanel.add(testCasePanel)
+            addSeparator()
+
+            generatedTestsTabData.allTestCasePanel.add(testCasePanelBuilder.getTestButton(), BorderLayout.EAST)
             addSeparator()
 
             generatedTestsTabData.testCaseNameToPanel[testCase.testName] = testCasePanel

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -167,13 +167,16 @@ class GeneratedTestsTabBuilder(
             generatedTestsTabData.allTestCasePanel.add(testCasePanel)
             addSeparator()
 
-            generatedTestsTabData.allTestCasePanel.add(testCasePanelBuilder.getTestButton(), BorderLayout.EAST)
-            addSeparator()
+            val testCaseDeleteButtonPanel: JPanel = testCasePanelBuilder.getTestButton()
+
+//            generatedTestsTabData.allTestCasePanel.add(testCasePanelBuilder.getTestButton(), BorderLayout.EAST)
+//            addSeparator()
 
             generatedTestsTabData.testCaseNameToPanel[testCase.testName] = testCasePanel
             generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName] = checkbox
             generatedTestsTabData.testCaseNameToEditorTextField[testCase.testName] =
                 testCasePanelBuilder.getEditorTextField()
+            generatedTestsTabData.testCaseNameToDeleteButton[testCase.testName] = testCaseDeleteButtonPanel
         }
         generatedTestsTabData.testsSelected = generatedTestsTabData.testCaseNameToPanel.size
         generatedTestsTabData.testCasePanelFactories.addAll(testCasePanelFactories)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -170,7 +170,7 @@ class GeneratedTestsTabBuilder(
             val testPanelIndex: Int =
                 generatedTestsTabData.allTestCasePanel.getComponentZOrder(testCasePanel)
 
-            val testCaseUndoRemoveButtonPanel: JPanel = testCasePanelBuilder.getUndoRemovePanel(testCase.testName, testPanelIndex)
+            val testCaseUndoRemoveButtonPanel: JPanel = testCasePanelBuilder.getUndoRemovePanel(testCase.testName, testCase.id, testPanelIndex)
 
             generatedTestsTabData.testCaseNameToPanel[testCase.testName] = testCasePanel
             generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName] = checkbox

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -12,6 +12,7 @@ class GeneratedTestsTabData {
     val testCaseNameToPanel: HashMap<String, JPanel> = HashMap()
     val testCaseNameToSelectedCheckbox: HashMap<String, JCheckBox> = HashMap()
     val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
+    val testCaseNameToUndoRemovePanel: HashMap<String, JPanel> = HashMap()
     var testsSelected: Int = 0
     val unselectedTestCases: HashMap<Int, TestCase> = HashMap()
     val testCasePanelFactories: ArrayList<TestCasePanelBuilder> = arrayListOf()
@@ -24,6 +25,4 @@ class GeneratedTestsTabData {
     var topButtonsPanelBuilder = TopButtonsPanelBuilder()
     var contentManager: ContentManager? = null
     var content: Content? = null
-
-    val testCaseNameToUndoRemovePanel: HashMap<String, JPanel> = HashMap()
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -5,6 +5,7 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
 import org.jetbrains.research.testspark.core.data.TestCase
+import javax.swing.JButton
 import javax.swing.JCheckBox
 import javax.swing.JPanel
 
@@ -24,4 +25,6 @@ class GeneratedTestsTabData {
     var topButtonsPanelBuilder = TopButtonsPanelBuilder()
     var contentManager: ContentManager? = null
     var content: Content? = null
+
+    val testCaseNameToDeleteButton: HashMap<String, JPanel> = HashMap()
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -12,7 +12,7 @@ class GeneratedTestsTabData {
     val testCaseNameToPanel: HashMap<String, JPanel> = HashMap()
     val testCaseNameToSelectedCheckbox: HashMap<String, JCheckBox> = HashMap()
     val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
-    val testCaseNameToUndoRemovePanel: HashMap<String, JPanel> = HashMap()
+    val testCaseNameToRemovePanel: HashMap<String, JPanel> = HashMap()
     var testsSelected: Int = 0
     val unselectedTestCases: HashMap<Int, TestCase> = HashMap()
     val testCasePanelFactories: ArrayList<TestCasePanelBuilder> = arrayListOf()

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -5,7 +5,6 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
 import org.jetbrains.research.testspark.core.data.TestCase
-import javax.swing.JButton
 import javax.swing.JCheckBox
 import javax.swing.JPanel
 
@@ -26,5 +25,5 @@ class GeneratedTestsTabData {
     var contentManager: ContentManager? = null
     var content: Content? = null
 
-    val testCaseNameToDeleteButton: HashMap<String, JPanel> = HashMap()
+    val testCaseNameToUndoRemovePanel: HashMap<String, JPanel> = HashMap()
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -345,10 +345,10 @@ class TestCasePanelBuilder(
     private fun undoRemove(testPanelIndex: Int) {
         generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToRemovePanel[testCase.testName])
 
-        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName]!!.setSelected(true)
-
         runTestButton.isEnabled = true
         isRemoved = false
+
+        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName]!!.setSelected(true)
 
         generatedTestsTabData.allTestCasePanel.add(
             generatedTestsTabData.testCaseNameToPanel[testCase.testName],

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -296,7 +296,7 @@ class TestCasePanelBuilder(
         }
         resetButton.addActionListener { reset() }
         resetToLastRunButton.addActionListener { resetToLastRun() }
-        removeButton.addActionListener { subtractTest() } // Can be replaced by any function
+        removeButton.addActionListener { subtractTest() }
 
         sendButton.addActionListener { sendRequest() }
 
@@ -313,36 +313,45 @@ class TestCasePanelBuilder(
     /**
      * Create button with text
      */
-    fun getUndoRemovePanel(testCaseName: String, testCaseId: Int, testPanelIndex: Int): JPanel {
+    fun getRemovePanel(testPanelIndex: Int): JPanel {
         val panel = JPanel()
 
         panel.layout = BoxLayout(panel, BoxLayout.X_AXIS)
 
-        val testButton = JButton("Return test")
+        val returnTestButton = JButton("Return test")
+        val removeTestButton = JButton("Remove test")
 
-        testButton.isOpaque = false
-        testButton.isContentAreaFilled = false
-        testButton.isBorderPainted = true
+        returnTestButton.isOpaque = false
+        returnTestButton.isContentAreaFilled = false
+        returnTestButton.isBorderPainted = true
 
-        testButton.addActionListener { undoRemove(testCaseName, testCaseId, testPanelIndex) }
+        removeTestButton.isOpaque = false
+        removeTestButton.isContentAreaFilled = false
+        removeTestButton.isBorderPainted = true
+
+        returnTestButton.addActionListener { undoRemove(testPanelIndex) }
+
+        removeTestButton.addActionListener { remove() }
 
         panel.add(Box.createHorizontalGlue())
 
-        panel.add(testButton)
+        panel.add(returnTestButton)
+
+        panel.add(removeTestButton)
 
         return panel
     }
 
-    private fun undoRemove(testCaseName: String, testCaseId: Int, testPanelIndex: Int) {
-        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToUndoRemovePanel[testCaseName])
+    private fun undoRemove(testPanelIndex: Int) {
+        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToRemovePanel[testCase.testName])
 
-        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.setSelected(true)
+        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName]!!.setSelected(true)
 
         runTestButton.isEnabled = true
         isRemoved = false
 
         generatedTestsTabData.allTestCasePanel.add(
-            generatedTestsTabData.testCaseNameToPanel[testCaseName],
+            generatedTestsTabData.testCaseNameToPanel[testCase.testName],
             testPanelIndex
         )
 
@@ -651,6 +660,8 @@ class TestCasePanelBuilder(
      * 3. Updating the UI.
      */
     private fun remove() {
+        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToRemovePanel[testCase.testName])
+
         // Remove the test case from the cache
         GenerateTestsTabHelper.removeTestCase(testCase.testName, generatedTestsTabData)
 
@@ -663,13 +674,16 @@ class TestCasePanelBuilder(
     }
 
     private fun subtractTest() {
-        val index: Int = GenerateTestsTabHelper.removeUITestCase(testCase.testName, generatedTestsTabData)
+        val index: Int =
+            generatedTestsTabData.allTestCasePanel.getComponentZOrder(generatedTestsTabData.testCaseNameToPanel[testCase.testName])
+
+        GenerateTestsTabHelper.removeUITestCase(testCase.testName, generatedTestsTabData)
 
         runTestButton.isEnabled = false
         isRemoved = true
 
         generatedTestsTabData.allTestCasePanel.add(
-            generatedTestsTabData.testCaseNameToUndoRemovePanel[testCase.testName],
+            generatedTestsTabData.testCaseNameToRemovePanel[testCase.testName],
             BorderLayout.EAST,
             index
         )

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -296,7 +296,7 @@ class TestCasePanelBuilder(
         }
         resetButton.addActionListener { reset() }
         resetToLastRunButton.addActionListener { resetToLastRun() }
-        removeButton.addActionListener { remove() } // Can be replaced by any funciton
+        removeButton.addActionListener { subtractTest() } // Can be replaced by any funciton
 
         sendButton.addActionListener { sendRequest() }
 
@@ -313,7 +313,7 @@ class TestCasePanelBuilder(
     /**
      * Create button with text
      */
-    fun getTestButton(): JPanel {
+    fun getUndoRemovePanel(testCaseName: String, testPanelIndex: Int): JPanel {
         val panel = JPanel()
 
         panel.layout = BoxLayout(panel, BoxLayout.X_AXIS)
@@ -324,11 +324,23 @@ class TestCasePanelBuilder(
         testButton.isContentAreaFilled = false
         testButton.isBorderPainted = true
 
-        panel.add(testButton)
+        testButton.addActionListener { undoRemove(testCaseName, testPanelIndex) }
 
         panel.add(Box.createHorizontalGlue())
 
+        panel.add(testButton)
+
         return panel
+    }
+
+    private fun undoRemove (testCaseName: String, testPanelIndex: Int) {
+        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToUndoRemovePanel[testCaseName])
+
+        if (!generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+            generatedTestsTabData.testsSelected++
+        }
+
+        generatedTestsTabData.allTestCasePanel.add(generatedTestsTabData.testCaseNameToPanel[testCaseName], testPanelIndex)
     }
 
     /**
@@ -634,6 +646,24 @@ class TestCasePanelBuilder(
      */
     private fun remove() {
         // Remove the test case from the cache
+//        val index: Int = GenerateTestsTabHelper.removeUITestCase(testCase.testName, generatedTestsTabData)
+        GenerateTestsTabHelper.removeTestCase(testCase.testName, generatedTestsTabData)
+
+        runTestButton.isEnabled = false
+        isRemoved = true
+
+        ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
+
+//        generatedTestsTabData.allTestCasePanel.add(
+//            generatedTestsTabData.testCaseNameToDeleteButton[testCase.testName],
+//            BorderLayout.EAST,
+//            index
+//        )
+
+        GenerateTestsTabHelper.update(generatedTestsTabData)
+    }
+
+    private fun subtractTest() {
         val index: Int = GenerateTestsTabHelper.removeUITestCase(testCase.testName, generatedTestsTabData)
 
         runTestButton.isEnabled = false
@@ -642,7 +672,7 @@ class TestCasePanelBuilder(
         ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
 
         generatedTestsTabData.allTestCasePanel.add(
-            generatedTestsTabData.testCaseNameToDeleteButton[testCase.testName],
+            generatedTestsTabData.testCaseNameToUndoRemovePanel[testCase.testName],
             BorderLayout.EAST,
             index
         )

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -296,7 +296,7 @@ class TestCasePanelBuilder(
         }
         resetButton.addActionListener { reset() }
         resetToLastRunButton.addActionListener { resetToLastRun() }
-        removeButton.addActionListener { subtractTest() }
+        removeButton.addActionListener { switchTestPanel() }
 
         sendButton.addActionListener { sendRequest() }
 
@@ -311,7 +311,7 @@ class TestCasePanelBuilder(
     }
 
     /**
-     * Create button with text
+     * Create a Panel that will replace test that was deleted by user.
      */
     fun getRemovePanel(testPanelIndex: Int): JPanel {
         val panel = JPanel()
@@ -342,6 +342,9 @@ class TestCasePanelBuilder(
         return panel
     }
 
+    /**
+     * Method that switch removed panel to test panel that was deleted.
+     */
     private fun undoRemove(testPanelIndex: Int) {
         generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToRemovePanel[testCase.testName])
 
@@ -673,7 +676,10 @@ class TestCasePanelBuilder(
         GenerateTestsTabHelper.update(generatedTestsTabData)
     }
 
-    private fun subtractTest() {
+    /**
+     * Switch test panel to removed panel of this test.
+     */
+    private fun switchTestPanel() {
         val index: Int =
             generatedTestsTabData.allTestCasePanel.getComponentZOrder(generatedTestsTabData.testCaseNameToPanel[testCase.testName])
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -48,16 +48,15 @@ import org.jetbrains.research.testspark.tools.ToolUtils
 import org.jetbrains.research.testspark.tools.factories.TestCompilerFactory
 import org.jetbrains.research.testspark.tools.llm.error.LLMErrorManager
 import org.jetbrains.research.testspark.tools.llm.test.JUnitTestSuitePresenter
+import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.StringSelection
-import java.util.Queue
+import java.util.*
+import javax.swing.*
 import javax.swing.border.Border
 import javax.swing.border.MatteBorder
-
-import java.awt.BorderLayout
-import javax.swing.*
 
 class TestCasePanelBuilder(
     private val project: Project,

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -53,17 +53,11 @@ import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.StringSelection
 import java.util.Queue
-import javax.swing.Box
-import javax.swing.BoxLayout
-import javax.swing.JButton
-import javax.swing.JCheckBox
-import javax.swing.JLabel
-import javax.swing.JOptionPane
-import javax.swing.JPanel
-import javax.swing.ScrollPaneConstants
-import javax.swing.SwingUtilities
 import javax.swing.border.Border
 import javax.swing.border.MatteBorder
+
+import java.awt.BorderLayout
+import javax.swing.*
 
 class TestCasePanelBuilder(
     private val project: Project,
@@ -640,15 +634,20 @@ class TestCasePanelBuilder(
      */
     private fun remove() {
         // Remove the test case from the cache
-        GenerateTestsTabHelper.removeTestCase(testCase.testName, generatedTestsTabData)
+        val index: Int = GenerateTestsTabHelper.removeUITestCase(testCase.testName, generatedTestsTabData)
 
         runTestButton.isEnabled = false
         isRemoved = true
 
         ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
 
+        generatedTestsTabData.allTestCasePanel.add(
+            generatedTestsTabData.testCaseNameToDeleteButton[testCase.testName],
+            BorderLayout.EAST,
+            index
+        )
+
         GenerateTestsTabHelper.update(generatedTestsTabData)
-//        print("THERE YOU ARE LITTLE PIECE OF SHIT!")
     }
 
     /**
@@ -720,7 +719,8 @@ class TestCasePanelBuilder(
      * Updates the current test case with the specified test name and test code.
      */
     private fun updateTestCaseInformation() {
-        testCase.testName = TestAnalyzerFactory.create(language).extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
+        testCase.testName = TestAnalyzerFactory.create(language)
+            .extractFirstTestMethodName(testCase.testName, languageTextField.document.text)
         testCase.testCode = languageTextField.document.text
     }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -296,7 +296,7 @@ class TestCasePanelBuilder(
         }
         resetButton.addActionListener { reset() }
         resetToLastRunButton.addActionListener { resetToLastRun() }
-        removeButton.addActionListener { subtractTest() } // Can be replaced by any funciton
+        removeButton.addActionListener { subtractTest() } // Can be replaced by any function
 
         sendButton.addActionListener { sendRequest() }
 
@@ -313,18 +313,18 @@ class TestCasePanelBuilder(
     /**
      * Create button with text
      */
-    fun getUndoRemovePanel(testCaseName: String, testPanelIndex: Int): JPanel {
+    fun getUndoRemovePanel(testCaseName: String, testCaseId: Int, testPanelIndex: Int): JPanel {
         val panel = JPanel()
 
         panel.layout = BoxLayout(panel, BoxLayout.X_AXIS)
 
-        val testButton = JButton("Test button")
+        val testButton = JButton("Return test")
 
         testButton.isOpaque = false
         testButton.isContentAreaFilled = false
         testButton.isBorderPainted = true
 
-        testButton.addActionListener { undoRemove(testCaseName, testPanelIndex) }
+        testButton.addActionListener { undoRemove(testCaseName, testCaseId, testPanelIndex) }
 
         panel.add(Box.createHorizontalGlue())
 
@@ -333,14 +333,20 @@ class TestCasePanelBuilder(
         return panel
     }
 
-    private fun undoRemove (testCaseName: String, testPanelIndex: Int) {
+    private fun undoRemove(testCaseName: String, testCaseId: Int, testPanelIndex: Int) {
         generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToUndoRemovePanel[testCaseName])
 
-        if (!generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
-            generatedTestsTabData.testsSelected++
-        }
+        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.setSelected(true)
 
-        generatedTestsTabData.allTestCasePanel.add(generatedTestsTabData.testCaseNameToPanel[testCaseName], testPanelIndex)
+        runTestButton.isEnabled = true
+        isRemoved = false
+
+        generatedTestsTabData.allTestCasePanel.add(
+            generatedTestsTabData.testCaseNameToPanel[testCaseName],
+            testPanelIndex
+        )
+
+        GenerateTestsTabHelper.update(generatedTestsTabData)
     }
 
     /**
@@ -646,19 +652,12 @@ class TestCasePanelBuilder(
      */
     private fun remove() {
         // Remove the test case from the cache
-//        val index: Int = GenerateTestsTabHelper.removeUITestCase(testCase.testName, generatedTestsTabData)
         GenerateTestsTabHelper.removeTestCase(testCase.testName, generatedTestsTabData)
 
         runTestButton.isEnabled = false
         isRemoved = true
 
         ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
-
-//        generatedTestsTabData.allTestCasePanel.add(
-//            generatedTestsTabData.testCaseNameToDeleteButton[testCase.testName],
-//            BorderLayout.EAST,
-//            index
-//        )
 
         GenerateTestsTabHelper.update(generatedTestsTabData)
     }
@@ -668,8 +667,6 @@ class TestCasePanelBuilder(
 
         runTestButton.isEnabled = false
         isRemoved = true
-
-        ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
 
         generatedTestsTabData.allTestCasePanel.add(
             generatedTestsTabData.testCaseNameToUndoRemovePanel[testCase.testName],

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -53,8 +53,16 @@ import java.awt.Dimension
 import java.awt.Toolkit
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.StringSelection
-import java.util.*
-import javax.swing.*
+import java.util.Queue
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JButton
+import javax.swing.JCheckBox
+import javax.swing.JLabel
+import javax.swing.JOptionPane
+import javax.swing.JPanel
+import javax.swing.ScrollPaneConstants
+import javax.swing.SwingUtilities
 import javax.swing.border.Border
 import javax.swing.border.MatteBorder
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -302,7 +302,7 @@ class TestCasePanelBuilder(
         }
         resetButton.addActionListener { reset() }
         resetToLastRunButton.addActionListener { resetToLastRun() }
-        removeButton.addActionListener { remove() }
+        removeButton.addActionListener { remove() } // Can be replaced by any funciton
 
         sendButton.addActionListener { sendRequest() }
 
@@ -312,6 +312,27 @@ class TestCasePanelBuilder(
          */
         requestComboBox.preferredSize = Dimension(0, 0)
         requestComboBox.isEditable = true
+
+        return panel
+    }
+
+    /**
+     * Create button with text
+     */
+    fun getTestButton(): JPanel {
+        val panel = JPanel()
+
+        panel.layout = BoxLayout(panel, BoxLayout.X_AXIS)
+
+        val testButton = JButton("Test button")
+
+        testButton.isOpaque = false
+        testButton.isContentAreaFilled = false
+        testButton.isBorderPainted = true
+
+        panel.add(testButton)
+
+        panel.add(Box.createHorizontalGlue())
 
         return panel
     }
@@ -627,6 +648,7 @@ class TestCasePanelBuilder(
         ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
 
         GenerateTestsTabHelper.update(generatedTestsTabData)
+//        print("THERE YOU ARE LITTLE PIECE OF SHIT!")
     }
 
     /**


### PR DESCRIPTION
# Description of changes made
This PR replaces the deleted test case with a panel that allows for restoring the test after its deletion, including all applied changes.

# Why is merge request needed
It is a significant improvement in user experience that can make the use of TestSpark more comfortable.

# Screen shot

![image_2024-10-17_10-53-00](https://github.com/user-attachments/assets/b56474cc-9558-45b0-a376-670e1e4858ba)


# What is missing?
"A collapsible window can be added to allow users to view the test before restoring it. Additionally, there can be fix of the issue with the field shape not displaying correctly after a test is removed.

- [x] I have checked that I am merging into correct branch
