### PR TITLE
Implement an undo button for deleted tests

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -33,7 +33,7 @@ object GenerateTestsTabHelper {
     }
 
     /**
-     * Helper function that removes a test from the cache.
+     * Helper function that removes a test from the cache if it stored.
      *
      * @param testCaseName the name of the test
      */
@@ -41,15 +41,19 @@ object GenerateTestsTabHelper {
         generatedTestsTabData: GeneratedTestsTabData,
         testCaseName: String
     ) {
-        // Remove all components from the cache
-        generatedTestsTabData.cacheTestCaseNameToSelectedCheckbox.remove(testCaseName)
-        generatedTestsTabData.cacheTestCaseNameToEditorTextField.remove(testCaseName)
-
-        generatedTestsTabData.cacheIndexToDeletedTestCaseName.remove(
-            generatedTestsTabData.allTestCasePanel.getComponentZOrder(
-                generatedTestsTabData.testCaseNameToPanel[testCaseName]
+        if (generatedTestsTabData.cacheTestCaseNameToSelectedCheckbox.containsKey(testCaseName)) {
+            generatedTestsTabData.cacheTestCaseNameToSelectedCheckbox.remove(testCaseName)
+        }
+        if (generatedTestsTabData.cacheTestCaseNameToEditorTextField.containsKey(testCaseName)) {
+            generatedTestsTabData.cacheTestCaseNameToEditorTextField.remove(testCaseName)
+        }
+        if (generatedTestsTabData.cacheIndexToDeletedTestCaseName.containsValue(testCaseName)) {
+            generatedTestsTabData.cacheIndexToDeletedTestCaseName.remove(
+                generatedTestsTabData.allTestCasePanel.getComponentZOrder(
+                    generatedTestsTabData.testCaseNameToPanel[testCaseName]
+                )
             )
-        )
+        }
     }
 
     /**
@@ -92,7 +96,8 @@ object GenerateTestsTabHelper {
         generatedTestsTabData.allTestCasePanel.remove(index)
 
         // Add the test back to the original position
-        val testPanel = generatedTestsTabData.testCaseNameToPanel[generatedTestsTabData.cacheIndexToDeletedTestCaseName[index]]
+        val testPanel =
+            generatedTestsTabData.testCaseNameToPanel[generatedTestsTabData.cacheIndexToDeletedTestCaseName[index]]
         generatedTestsTabData.allTestCasePanel.add(testPanel, index)
 
         // Restore the checkbox

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -1,5 +1,7 @@
 package org.jetbrains.research.testspark.display.generatedTests
 
+import javax.swing.JPanel
+
 object GenerateTestsTabHelper {
     /**
      * A helper method to remove a test case from the cache and from the UI.
@@ -7,23 +9,109 @@ object GenerateTestsTabHelper {
      * @param testCaseName the name of the test
      */
     fun removeTestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
+        // Remove the test from the cache if it is already removed from the UI
+        if (generatedTestsTabData.cacheIndexToDeletedTestCaseName.containsValue(testCaseName)) {
+            removeTestFromCache(generatedTestsTabData, testCaseName)
+        } else {
+            // Update the number of selected test cases if necessary
+            if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+                generatedTestsTabData.testsSelected--
+            }
+
+            // Remove the test panel from the UI
+            generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
+
+            // Remove the selected checkbox
+            generatedTestsTabData.testCaseNameToSelectedCheckbox.remove(testCaseName)
+
+            // Remove the editorTextField
+            generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
+        }
+
+        // Remove the test panel
+        generatedTestsTabData.testCaseNameToPanel.remove(testCaseName)
+    }
+
+    /**
+     * Helper function that removes a test from the cache.
+     *
+     * @param testCaseName the name of the test
+     */
+    private fun removeTestFromCache(
+        generatedTestsTabData: GeneratedTestsTabData,
+        testCaseName: String
+    ) {
+        // Remove all components from the cache
+        generatedTestsTabData.cacheTestCaseNameToSelectedCheckbox.remove(testCaseName)
+        generatedTestsTabData.cacheTestCaseNameToEditorTextField.remove(testCaseName)
+
+        generatedTestsTabData.cacheIndexToDeletedTestCaseName.remove(
+            generatedTestsTabData.allTestCasePanel.getComponentZOrder(
+                generatedTestsTabData.testCaseNameToPanel[testCaseName]
+            )
+        )
+    }
+
+    /**
+     * A helper method to remove one test case from the UI and store it in the cache.
+     *
+     * @param testCaseName the name of the test
+     */
+    fun removeTestCaseFromUI(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData): Int {
         // Update the number of selected test cases if necessary
         if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
             generatedTestsTabData.testsSelected--
         }
 
-        // Remove the test panel from the UI
-        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
+        // Find the index at which the test is
+        val index = generatedTestsTabData.allTestCasePanel
+            .getComponentZOrder(generatedTestsTabData.testCaseNameToPanel[testCaseName])
 
-        // Remove the test panel
-        generatedTestsTabData.testCaseNameToPanel.remove(testCaseName)
+        // Remove the test from the UI
+        generatedTestsTabData.allTestCasePanel.remove(index)
 
-        // Remove the selected checkbox
+        // Add test name to the deleted list
+        generatedTestsTabData.cacheIndexToDeletedTestCaseName[index] = testCaseName
+
+        // Remove the selected checkbox, but save it in the cache
+        generatedTestsTabData.cacheTestCaseNameToSelectedCheckbox[testCaseName] =
+            generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!
         generatedTestsTabData.testCaseNameToSelectedCheckbox.remove(testCaseName)
 
-        // Remove the editorTextField
+        // Remove the editorTextField, but save it in the cache
+        generatedTestsTabData.cacheTestCaseNameToEditorTextField[testCaseName] =
+            generatedTestsTabData.testCaseNameToEditorTextField[testCaseName]!!
         generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
+
+        return index
     }
+
+    fun restoreTestCaseToUI(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData, undoPanel: JPanel) {
+        // Remove the Undo panel
+        val index: Int = generatedTestsTabData.allTestCasePanel.getComponentZOrder(undoPanel)
+        generatedTestsTabData.allTestCasePanel.remove(index)
+
+        // Add the test back to the original position
+        val testPanel = generatedTestsTabData.testCaseNameToPanel[generatedTestsTabData.cacheIndexToDeletedTestCaseName[index]]
+        generatedTestsTabData.allTestCasePanel.add(testPanel, index)
+
+        // Restore the checkbox
+        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName] =
+            generatedTestsTabData.cacheTestCaseNameToSelectedCheckbox[testCaseName]!!
+
+        // Restore the editorTextField
+        generatedTestsTabData.testCaseNameToEditorTextField[testCaseName] =
+            generatedTestsTabData.cacheTestCaseNameToEditorTextField[testCaseName]!!
+
+        // Update the number of selected test cases if necessary
+        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+            generatedTestsTabData.testsSelected++
+        }
+
+        // Remove the re-added test from the cache
+        removeTestFromCache(generatedTestsTabData, generatedTestsTabData.cacheIndexToDeletedTestCaseName[index]!!)
+    }
+
 
     /**
      * Updates the user interface of the tool window.

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -191,6 +191,7 @@ class GeneratedTestsTabBuilder(
         // Filter the selected test cases
         val selectedTestCasePanels =
             generatedTestsTabData.testCaseNameToPanel.filter { (it.value.getComponent(0) as JCheckBox).isSelected }
+                .filter { !generatedTestsTabData.cacheIndexToDeletedTestCaseName.containsValue(it.key) }
         val selectedTestCases = selectedTestCasePanels.map { it.key }
 
         // Get the test case components (source code of the tests)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -16,6 +16,9 @@ class GeneratedTestsTabData {
     val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
     var testsSelected: Int = 0
     val unselectedTestCases: HashMap<Int, TestCase> = HashMap()
+    val cacheIndexToDeletedTestCaseName: HashMap<Int, String> = HashMap()
+    val cacheTestCaseNameToSelectedCheckbox: HashMap<String, JCheckBox> = HashMap()
+    val cacheTestCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
     val testCasePanelFactories: ArrayList<TestCasePanelBuilder> = arrayListOf()
     var allTestCasePanel: JPanel = JPanel()
     val applyButton: JButton = JButton(PluginLabelsBundle.get("applyButton"))

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
@@ -53,13 +53,13 @@ class TopButtonsPanelBuilder {
         testsSelectedLabel.text = String.format(
             testsSelectedText,
             generatedTestsTabData.testsSelected,
-            generatedTestsTabData.testCaseNameToPanel.size,
+            generatedTestsTabData.testCaseNameToPanel.size - generatedTestsTabData.cacheIndexToDeletedTestCaseName.size,
         )
         testsPassedLabel.text =
             String.format(
                 testsPassedText,
                 passedTestsCount,
-                generatedTestsTabData.testCaseNameToPanel.size,
+                generatedTestsTabData.testCaseNameToPanel.size - generatedTestsTabData.cacheIndexToDeletedTestCaseName.size,
             )
         runAllButton.isEnabled = false
         for (testCasePanelFactory in generatedTestsTabData.testCasePanelFactories) {
@@ -76,11 +76,14 @@ class TopButtonsPanelBuilder {
      *  @param selected whether the checkboxes have to be selected or not
      */
     private fun toggleAllCheckboxes(selected: Boolean, generatedTestsTabData: GeneratedTestsTabData) {
-        generatedTestsTabData.testCaseNameToPanel.forEach { (_, jPanel) ->
-            val checkBox = jPanel.getComponent(0) as JCheckBox
-            checkBox.isSelected = selected
-        }
-        generatedTestsTabData.testsSelected = if (selected) generatedTestsTabData.testCaseNameToPanel.size else 0
+        generatedTestsTabData.testCaseNameToPanel
+            .filter { !generatedTestsTabData.cacheIndexToDeletedTestCaseName.containsValue(it.key) }
+            .forEach { (_, jPanel) ->
+                val checkBox = jPanel.getComponent(0) as JCheckBox
+                checkBox.isSelected = selected
+            }
+        generatedTestsTabData.testsSelected =
+            if (selected) generatedTestsTabData.testCaseNameToPanel.size - generatedTestsTabData.cacheIndexToDeletedTestCaseName.size else 0
     }
 
     /**

--- a/src/main/resources/properties/plugin/PluginLabels.properties
+++ b/src/main/resources/properties/plugin/PluginLabels.properties
@@ -27,6 +27,7 @@ send=Send
 applyButton=Apply to test suite
 testsSelected=Selected
 testsPassed=Passed
+undoTestDelete=Revert test removal
 !Chooser window
 optionPaneMessage=Input the name of a new file
 optionPaneTitle=File name


### PR DESCRIPTION
# Description of changes made
When a user clicks the trash icon next to a generated test the following happens:
1. The test is replaced with a confirmation and a button that allows them to undo.
2. The deleted test is stored in the cache.
3. The statistics in the top bar are updated accordingly (behavior existed before).

If the user chooses to undo the deletion:
1. The test appears back in the original position, including:
  a. all changes made by the user to the original test
  b. the highlighting that indicates if the test previously passed/failed
  c. the checkbox in the same state as before deletion (either selected or not)
3. The statistics are updated in the top bar.
4. The reverted test is removed from the cache.

Other affected features:
1. **Deleting all tests with the trash icon from the top bar**: All tests get deleted both from the UI and the cache.
2. **Apply test suite**: Only the tests selected and not deleted are added to the test suite and other tests are removed from the cache.
3. **(De-)selecting all tests**: Works as expected and only (de-)selects the visible tests.

# Why is merge request needed
This feature allows users to revert the deletion of an individual test from the TestSpark panel.

# Screenshots

| ![Original UI](https://github.com/user-attachments/assets/099b8a0d-a4fa-4799-9344-7ab48689dc01) | ![UI after test deletion](https://github.com/user-attachments/assets/91372a2b-7c2a-463b-a6e2-7b383f049a5f) |
|-------------------------|-------------------------|

# Other notes
Closes #230.

- [x] I have checked that I am merging into correct branch
