### PR TITLE
Feature: Undo test case deletion

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -2,27 +2,53 @@ package org.jetbrains.research.testspark.display.generatedTests
 
 object GenerateTestsTabHelper {
     /**
-     * A helper method to remove a test case from the cache and from the UI.
+     * A helper method to remove a test case from the cache.
      *
      * @param testCaseName the name of the test
      */
     fun removeTestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
-        // Update the number of selected test cases if necessary
-        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
-            generatedTestsTabData.testsSelected--
-        }
-
-        // Remove the test panel from the UI
-        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
-
         // Remove the test panel
-        generatedTestsTabData.testCaseNameToPanel.remove(testCaseName)
+        val panel = generatedTestsTabData.testCaseNameToPanel.remove(testCaseName)
 
         // Remove the selected checkbox
-        generatedTestsTabData.testCaseNameToSelectedCheckbox.remove(testCaseName)
+        val checkbox = generatedTestsTabData.testCaseNameToSelectedCheckbox.remove(testCaseName)
 
         // Remove the editorTextField
-        generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
+        val editorTextField = generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
+
+        // Save data for possible restoration
+        val deletedTest = DeletedTest(panel!!, checkbox!!, editorTextField!!)
+        generatedTestsTabData.testCaseNameToDeletedTestData[testCaseName] = deletedTest
+    }
+
+    /**
+     * A helper method to restore a previously deleted test case to the cache.
+     *
+     * @param testCaseName the name of the test
+     */
+    fun restoreTestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
+        // Retrieve information about previously deleted test
+        val deletedTest = generatedTestsTabData.testCaseNameToDeletedTestData.remove(testCaseName)!!
+
+        // Re-add the test panel
+        generatedTestsTabData.testCaseNameToPanel[testCaseName] = deletedTest.panel
+
+        // Re-add the selected checkbox
+        generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName] = deletedTest.checkbox
+
+        // Re-add the editorTextField
+        generatedTestsTabData.testCaseNameToEditorTextField[testCaseName] = deletedTest.editorTextField
+    }
+
+    /**
+     * A helper method to remove all test cases from the cache and UI.
+     */
+    fun clear(generatedTestsTabData: GeneratedTestsTabData) {
+        generatedTestsTabData.allTestCasePanel.removeAll()
+        generatedTestsTabData.testCaseNameToPanel.clear()
+        generatedTestsTabData.testCaseNameToSelectedCheckbox.clear()
+        generatedTestsTabData.testCaseNameToEditorTextField.clear()
+        generatedTestsTabData.testCaseNameToDeletedTestData.clear()
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -245,8 +245,7 @@ class GeneratedTestsTabBuilder(
      * Clears all the generated test cases from the UI and the internal cache.
      */
     fun clear() {
-        generatedTestsTabData.testCaseNameToPanel.toMap()
-            .forEach { GenerateTestsTabHelper.removeTestCase(it.key, generatedTestsTabData) }
+        GenerateTestsTabHelper.clear(generatedTestsTabData)
         generatedTestsTabData.testCasePanelFactories.clear()
         generatedTestsTabData.topButtonsPanelBuilder.clear(generatedTestsTabData)
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -14,6 +14,7 @@ class GeneratedTestsTabData {
     val testCaseNameToPanel: HashMap<String, JPanel> = HashMap()
     val testCaseNameToSelectedCheckbox: HashMap<String, JCheckBox> = HashMap()
     val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
+    val testCaseNameToDeletedTestData: HashMap<String, DeletedTest> = HashMap()
     var testsSelected: Int = 0
     val unselectedTestCases: HashMap<Int, TestCase> = HashMap()
     val testCasePanelFactories: ArrayList<TestCasePanelBuilder> = arrayListOf()
@@ -28,3 +29,5 @@ class GeneratedTestsTabData {
     var contentManager: ContentManager? = null
     var content: Content? = null
 }
+
+data class DeletedTest(val panel: JPanel, val checkbox: JCheckBox, val editorTextField: EditorTextField)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -307,11 +307,7 @@ class TestCasePanelBuilder(
 
         val deletedTestPanel = createDeletedTestPanel()
         removeButton.addActionListener {
-            enableLocalComponents(false)
             deletedTestPanel.isVisible = true
-            languageTextField.isEnabled = false
-            checkbox.isSelected = false
-            checkbox.isEnabled = false
             remove()
         }
 
@@ -354,10 +350,6 @@ class TestCasePanelBuilder(
 
         undoButton.addActionListener {
             deletedTestPanel.isVisible = false
-            languageTextField.isEnabled = true
-            checkbox.isSelected = true
-            checkbox.isEnabled = true
-            enableLocalComponents(true)
             restore()
         }
 
@@ -678,7 +670,13 @@ class TestCasePanelBuilder(
         // Remove the test case from the cache
         GenerateTestsTabHelper.removeTestCase(testCase.testName, generatedTestsTabData)
 
+        // Disable UI
+        enableLocalComponents(false)
+        languageTextField.isEnabled = false
+        checkbox.isSelected = false
+        checkbox.isEnabled = false
         runTestButton.isEnabled = false
+
         isRemoved = true
 
         ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
@@ -687,9 +685,16 @@ class TestCasePanelBuilder(
     }
 
     private fun restore() {
+        // Restore test case to cache
         GenerateTestsTabHelper.restoreTestCase(testCase.testName, generatedTestsTabData)
 
+        // Enable UI
+        enableLocalComponents(true)
+        languageTextField.isEnabled = true
+        checkbox.isSelected = true
+        checkbox.isEnabled = true
         runTestButton.isEnabled = true
+
         isRemoved = false
 
         ReportUpdater.restoreTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -324,8 +324,8 @@ class TestCasePanelBuilder(
         requestComboBox.preferredSize = Dimension(0, 0)
         requestComboBox.isEditable = true
 
-        val overlayPanel = object: JPanel() {
-            override fun isOptimizedDrawingEnabled()  = false
+        val overlayPanel = object : JPanel() {
+            override fun isOptimizedDrawingEnabled() = false
         }.apply {
             layout = OverlayLayout(this)
             add(deletedTestPanel)
@@ -341,11 +341,11 @@ class TestCasePanelBuilder(
     private fun createDeletedTestPanel(): JPanel {
         val deletedTestPanel = JPanel().apply {
             this.isVisible = false
-            this.addMouseListener(object: MouseAdapter() {})
-        };
+            this.addMouseListener(object : MouseAdapter() {})
+        }
 
         deletedTestPanel.add(Box.createRigidArea(Dimension(15, 0)))
-        deletedTestPanel.add( JLabel("This test case has been deleted."))
+        deletedTestPanel.add(JLabel("This test case has been deleted."))
         deletedTestPanel.add(Box.createHorizontalGlue())
 
         val undoButton = JButton("Undo")

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/ReportUpdater.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/ReportUpdater.kt
@@ -29,6 +29,17 @@ object ReportUpdater {
         coverageVisualisationTabBuilder.show(report, generatedTestsTabData)
     }
 
+    fun restoreTestCase(
+        report: Report,
+        testCase: TestCase,
+        coverageVisualisationTabBuilder: CoverageVisualisationTabBuilder,
+        generatedTestsTabData: GeneratedTestsTabData,
+    ) {
+        report.testCaseList[testCase.id] = testCase
+        report.normalized()
+        coverageVisualisationTabBuilder.show(report, generatedTestsTabData)
+    }
+
     fun unselectTestCase(
         report: Report,
         unselectedTestCases: HashMap<Int, TestCase>,


### PR DESCRIPTION
# Description of changes made
This PR implements the ability for a user to undo the deletion of a test case if they change their mind. The general procedure is as follows:

- When the user decides to delete a test case, instead of irrevocably removing the test from the UI and cache, the test is marked as deleted in the UI and the cache data is moved to a separate cache for "deleted" test cases
- In place of the bottom panel of the "deleted" test, the user is presented with a button to undo this operation; the original test code is still visible for inspection
- If the user decides to undo the deletion, the test together with its UI is enabled again, and the cache data is moved back to the original cache
- The top bar with the current stats as well as the coverage indicators on the gutter are updated accordingly

# Screenshot
![undo-test-case-removal-example](https://github.com/user-attachments/assets/e26c9311-aa6d-4680-9884-8d0c36dc0212)

# Other notes
Closes #230 

# What is missing?
When the number of deleted test cases is large, they may clutter the list of test cases. In addition to an undo button, one could add a button to permanently remove the test case from the UI.

- [x] I have checked that I am merging into correct branch
