### PR TITLE
Quote compilers' filepaths with "" for Windows

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -42,12 +42,15 @@ class JavaTestCompiler(
     override fun compileCode(path: String, projectBuildPath: String, workingDir: String): ExecutionResult {
         val classPaths = "\"${getClassPaths(projectBuildPath)}\""
         // compile file
+        // See: https://github.com/JetBrains-Research/TestSpark/issues/402
+        val javac = if (DataFilesUtil.isWindows()) "\"$javac\"" else "'$javac'"
+
         val executionResult = CommandLineRunner.run(
             arrayListOf(
                 /**
                  * Filepath may contain spaces, so we need to wrap it in quotes.
                  */
-                "'$javac'",
+                javac,
                 "-cp",
                 classPaths,
                 path,

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -56,12 +56,15 @@ class KotlinTestCompiler(
 
         val classPaths = "\"${getClassPaths(projectBuildPath)}\""
         // Compile file
+        // See: https://github.com/JetBrains-Research/TestSpark/issues/402
+        val kotlinc = if (DataFilesUtil.isWindows()) "\"$kotlinc\"" else "'$kotlinc'"
+
         val executionResult = CommandLineRunner.run(
             arrayListOf(
                 /**
                  * Filepath may contain spaces, so we need to wrap it in quotes.
                  */
-                "'$kotlinc'",
+                kotlinc,
                 "-cp",
                 classPaths,
                 path,


### PR DESCRIPTION
# Description of changes made
Closes #402 

*Please write if you have anything to add*

I still treat non-Windows systems separately: I used a single quote `' '` to escape compilers' filepaths for Unix because bash treats a single quote as plain text, the double quote may contain command calls.

I tested both on Windows and Mac; the error from the issue got resolved. For Windows though, there is another one #407, which is not covered here.

- [x] I have checked that I am merging into correct branch
