### PR TITLE
Using JUnit 4 for EvoSuit

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -206,6 +206,7 @@ class TestSparkStarter : ApplicationStarter {
                                     projectContext,
                                     projectSDKPath,
                                     testCompiler,
+                                    settingsState.junitVersion,
                                 )
                             }
                         } else {
@@ -253,6 +254,7 @@ class TestSparkStarter : ApplicationStarter {
         projectContext: ProjectContext,
         projectSDKPath: Path,
         testCompiler: TestCompiler,
+        junitVersion: JUnitVersion,
     ) {
         val targetDirectory = "$out${File.separator}${packageList.joinToString(File.separator)}"
         println("Run tests in $targetDirectory")
@@ -272,6 +274,7 @@ class TestSparkStarter : ApplicationStarter {
                     out,
                     projectContext,
                     testCompiler,
+                    junitVersion
                 )
                 // Saving exception (if exists) thrown during the test execution
                 saveException(testcaseName, targetDirectory, testExecutionError)

--- a/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/appstarter/TestSparkStarter.kt
@@ -274,7 +274,7 @@ class TestSparkStarter : ApplicationStarter {
                     out,
                     projectContext,
                     testCompiler,
-                    junitVersion
+                    junitVersion,
                 )
                 // Saving exception (if exists) thrown during the test execution
                 saveException(testcaseName, targetDirectory, testExecutionError)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/TestSparkDisplayManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/TestSparkDisplayManager.kt
@@ -13,6 +13,7 @@ import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.data.UIContext
 import org.jetbrains.research.testspark.display.coverage.CoverageVisualisationTabBuilder
 import org.jetbrains.research.testspark.display.generatedTests.GeneratedTestsTabBuilder
+import org.jetbrains.research.testspark.tools.GenerationTool
 import org.jetbrains.research.testspark.tools.TestsExecutionResultManager
 import java.awt.Component
 import javax.swing.JOptionPane
@@ -41,14 +42,30 @@ class TestSparkDisplayManager {
     /**
      * Fill the panel with the generated test cases.
      */
-    fun display(report: Report, editor: Editor, uiContext: UIContext, language: SupportedLanguage, project: Project, testsExecutionResultManager: TestsExecutionResultManager) {
+    fun display(
+        report: Report,
+        editor: Editor,
+        uiContext: UIContext,
+        language: SupportedLanguage,
+        project: Project,
+        testsExecutionResultManager: TestsExecutionResultManager,
+        generationTool: GenerationTool,
+    ) {
         this.toolWindow = ToolWindowManager.getInstance(project).getToolWindow("TestSpark")
         this.contentManager = toolWindow!!.contentManager
 
         this.editor = editor
 
         coverageVisualisationTabBuilder = CoverageVisualisationTabBuilder(project, editor)
-        generatedTestsTabBuilder = GeneratedTestsTabBuilder(project, report, editor, uiContext, coverageVisualisationTabBuilder!!, testsExecutionResultManager)
+        generatedTestsTabBuilder = GeneratedTestsTabBuilder(
+            project,
+            report,
+            editor,
+            uiContext,
+            coverageVisualisationTabBuilder!!,
+            testsExecutionResultManager,
+            generationTool
+        )
 
         generatedTestsTabBuilder!!.show(contentManager!!, language)
         coverageVisualisationTabBuilder!!.show(report, generatedTestsTabBuilder!!.generatedTestsTabData())

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/TestSparkDisplayManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/TestSparkDisplayManager.kt
@@ -64,7 +64,7 @@ class TestSparkDisplayManager {
             uiContext,
             coverageVisualisationTabBuilder!!,
             testsExecutionResultManager,
-            generationTool
+            generationTool,
         )
 
         generatedTestsTabBuilder!!.show(contentManager!!, language)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -15,6 +15,7 @@ import org.jetbrains.research.testspark.display.utils.ReportUpdater
 import org.jetbrains.research.testspark.display.utils.java.JavaDisplayUtils
 import org.jetbrains.research.testspark.display.utils.kotlin.KotlinDisplayUtils
 import org.jetbrains.research.testspark.display.utils.template.DisplayUtils
+import org.jetbrains.research.testspark.tools.GenerationTool
 import org.jetbrains.research.testspark.tools.TestsExecutionResultManager
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -36,6 +37,7 @@ class GeneratedTestsTabBuilder(
     private val uiContext: UIContext,
     private val coverageVisualisationTabBuilder: CoverageVisualisationTabBuilder,
     private val testsExecutionResultManager: TestsExecutionResultManager,
+    private val generationTool: GenerationTool
 ) {
     private val generatedTestsTabData: GeneratedTestsTabData = GeneratedTestsTabData()
 
@@ -149,8 +151,17 @@ class GeneratedTestsTabBuilder(
 
             val testCasePanelBuilder =
                 TestCasePanelBuilder(
-                    project, language, testCase, editor, checkbox, uiContext, report,
-                    coverageVisualisationTabBuilder, generatedTestsTabData, testsExecutionResultManager,
+                    project,
+                    language,
+                    testCase,
+                    editor,
+                    checkbox,
+                    uiContext,
+                    report,
+                    coverageVisualisationTabBuilder,
+                    generatedTestsTabData,
+                    testsExecutionResultManager,
+                    generationTool
                 )
             testCasePanel.add(testCasePanelBuilder.getUpperPanel(), BorderLayout.NORTH)
             testCasePanel.add(testCasePanelBuilder.getMiddlePanel(), BorderLayout.CENTER)
@@ -238,7 +249,8 @@ class GeneratedTestsTabBuilder(
             generatedTestsTabData.contentManager?.removeContent(generatedTestsTabData.content!!, true)
             ToolWindowManager.getInstance(project).getToolWindow("TestSpark")?.hide()
             coverageVisualisationTabBuilder.closeToolWindowTab()
-        } catch (_: AlreadyDisposedException) {} // Make sure the process continues if the tool window is already closed
+        } catch (_: AlreadyDisposedException) {
+        } // Make sure the process continues if the tool window is already closed
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -37,7 +37,7 @@ class GeneratedTestsTabBuilder(
     private val uiContext: UIContext,
     private val coverageVisualisationTabBuilder: CoverageVisualisationTabBuilder,
     private val testsExecutionResultManager: TestsExecutionResultManager,
-    private val generationTool: GenerationTool
+    private val generationTool: GenerationTool,
 ) {
     private val generatedTestsTabData: GeneratedTestsTabData = GeneratedTestsTabData()
 
@@ -161,7 +161,7 @@ class GeneratedTestsTabBuilder(
                     coverageVisualisationTabBuilder,
                     generatedTestsTabData,
                     testsExecutionResultManager,
-                    generationTool
+                    generationTool,
                 )
             testCasePanel.add(testCasePanelBuilder.getUpperPanel(), BorderLayout.NORTH)
             testCasePanel.add(testCasePanelBuilder.getMiddlePanel(), BorderLayout.CENTER)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -22,6 +22,7 @@ import com.intellij.util.ui.JBUI
 import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginLabelsBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
+import org.jetbrains.research.testspark.core.data.JUnitVersion
 import org.jetbrains.research.testspark.core.data.Report
 import org.jetbrains.research.testspark.core.data.TestCase
 import org.jetbrains.research.testspark.core.generation.llm.getClassWithTestCaseName
@@ -42,6 +43,7 @@ import org.jetbrains.research.testspark.helpers.LLMHelper
 import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.settings.llm.LLMSettingsState
 import org.jetbrains.research.testspark.testmanager.TestAnalyzerFactory
+import org.jetbrains.research.testspark.tools.GenerationTool
 import org.jetbrains.research.testspark.tools.TestProcessor
 import org.jetbrains.research.testspark.tools.TestsExecutionResultManager
 import org.jetbrains.research.testspark.tools.ToolUtils
@@ -64,8 +66,6 @@ import javax.swing.ScrollPaneConstants
 import javax.swing.SwingUtilities
 import javax.swing.border.Border
 import javax.swing.border.MatteBorder
-import org.jetbrains.research.testspark.core.data.JUnitVersion
-import org.jetbrains.research.testspark.tools.GenerationTool
 
 class TestCasePanelBuilder(
     private val project: Project,
@@ -574,7 +574,7 @@ class TestCasePanelBuilder(
                 uiContext.projectContext,
                 testCompiler,
                 testsExecutionResultManager,
-                junitVersion
+                junitVersion,
             )
 
         testCase.coveredLines = newTestCase.coveredLines

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/GenerationTool.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/GenerationTool.kt
@@ -5,7 +5,8 @@ package org.jetbrains.research.testspark.tools
  */
 enum class GenerationTool(val toolId: String) {
     EvoSuite("EvoSuite"),
-    LLM("LLM");
+    LLM("LLM"),
+    ;
 
     companion object {
         fun from(findValue: String): GenerationTool = entries.first { it.toolId == findValue }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/GenerationTool.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/GenerationTool.kt
@@ -1,0 +1,13 @@
+package org.jetbrains.research.testspark.tools
+
+/**
+ * Enum class representing strategy for test generation
+ */
+enum class GenerationTool(val toolId: String) {
+    EvoSuite("EvoSuite"),
+    LLM("LLM");
+
+    companion object {
+        fun from(findValue: String): GenerationTool = entries.first { it.toolId == findValue }
+    }
+}

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/Pipeline.kt
@@ -34,6 +34,7 @@ import java.util.UUID
  * @param caretOffset the offset of the caret position in the PSI file.
  * @param fileUrl the URL of the file being processed, if applicable.
  * @param packageName the package name of the file being processed.
+ * @param generationToolName the tool name chosen for generation
  */
 class Pipeline(
     private val project: Project,
@@ -44,9 +45,11 @@ class Pipeline(
     private val testGenerationController: TestGenerationController,
     private val testSparkDisplayManager: TestSparkDisplayManager,
     private val testsExecutionResultManager: TestsExecutionResultManager,
+    generationToolName: String,
 ) {
     val projectContext: ProjectContext = ProjectContext()
     val generatedTestsData = TestGenerationData()
+    val generationTool = GenerationTool.from(generationToolName)
 
     init {
         val cutPsiClass = psiHelper.getSurroundingClass(caretOffset)
@@ -134,6 +137,7 @@ class Pipeline(
                             psiHelper.language,
                             project,
                             testsExecutionResultManager,
+                            generationTool,
                         )
                     }
                 }
@@ -141,14 +145,15 @@ class Pipeline(
                 private fun updateEditor(fileUrl: String) {
                     val documentManager = FileDocumentManager.getInstance()
                     // https://intellij-support.jetbrains.com/hc/en-us/community/posts/360004480599/comments/360000703299
-                    FileEditorManager.getInstance(project).selectedEditors.map { it as TextEditor }.map { it.editor }.map {
-                        val currentFile = documentManager.getFile(it.document)
-                        if (currentFile != null) {
-                            if (currentFile.presentableUrl == fileUrl) {
-                                editor = it
+                    FileEditorManager.getInstance(project).selectedEditors.map { it as TextEditor }.map { it.editor }
+                        .map {
+                            val currentFile = documentManager.getFile(it.document)
+                            if (currentFile != null) {
+                                if (currentFile.presentableUrl == fileUrl) {
+                                    editor = it
+                                }
                             }
                         }
-                    }
                 }
             })
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -157,7 +157,7 @@ class TestProcessor(
         projectContext: ProjectContext,
         testCompiler: TestCompiler,
         testsExecutionResultManager: TestsExecutionResultManager,
-        junitVersion: JUnitVersion
+        junitVersion: JUnitVersion,
     ): TestCase {
         // get buildPath
         var buildPath: String = ProjectRootManager.getInstance(project).contentRoots.first().path

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -101,7 +101,7 @@ class TestProcessor(
                 javaAgentFlag,
                 "-cp",
                 "\"${testCompiler.getClassPaths(projectBuildPath)}${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath\"",
-                "org.jetbrains.research.SingleJUnitTestRunner$junitVersion",
+                "org.jetbrains.research.SingleJUnitTestRunner${junitVersion.version}",
                 name,
             ),
         )

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
@@ -184,7 +184,7 @@ class EvoSuite(override val name: String = "EvoSuite") : Tool {
             testGenerationController,
             testSparkDisplayManager,
             testsExecutionResultManager,
-            name
+            name,
         )
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
@@ -184,6 +184,7 @@ class EvoSuite(override val name: String = "EvoSuite") : Tool {
             testGenerationController,
             testSparkDisplayManager,
             testsExecutionResultManager,
+            name
         )
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -218,6 +218,7 @@ class Llm(override val name: String = "LLM") : Tool {
                 testGenerationController,
                 testSparkDisplayManager,
                 testsExecutionResultManager,
+                name
             )
 
             val manager = LLMProcessManager(

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -218,7 +218,7 @@ class Llm(override val name: String = "LLM") : Tool {
                 testGenerationController,
                 testSparkDisplayManager,
                 testsExecutionResultManager,
-                name
+                name,
             )
 
             val manager = LLMProcessManager(


### PR DESCRIPTION
# Description of changes made
I've provided information about the type of generation tools used in the TestCasePanel to be able to choose the JUnit version, not depending on LLM settings.

Closes #408

# Notes

Probably there is a more accurate way to restrict the junit version, i.e., specify it in TestCase class when it's created. But in my opinion, it's strange, that the test case panel does not know anything about the method we've generated tests, while it can have different settings options affecting compilation and running tests.

- [x] I have checked that I am merging into the correct branch
