### PR TITLE
Implement undo delete test case functionality

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -8,12 +8,12 @@ object GenerateTestsTabHelper {
      */
     fun removeTestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
         // Update the number of selected test cases if necessary
-        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+        val testCaseIsSelected = generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected
+        val testCaseIsNotHidden = !generatedTestsTabData.hiddenTestCases.contains(testCaseName)
+        generatedTestsTabData.hiddenTestCases.remove(testCaseName)
+        if (testCaseIsSelected && testCaseIsNotHidden) {
             generatedTestsTabData.testsSelected--
         }
-
-        // Remove the test panel from the UI
-        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
 
         // Remove the test panel
         generatedTestsTabData.testCaseNameToPanel.remove(testCaseName)
@@ -23,6 +23,27 @@ object GenerateTestsTabHelper {
 
         // Remove the editorTextField
         generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
+    }
+
+    fun showTestCase(
+        testCaseName: String,
+        generatedTestsTabData: GeneratedTestsTabData,
+    ) {
+        generatedTestsTabData.hiddenTestCases.remove(testCaseName)
+        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+            generatedTestsTabData.testsSelected++
+        }
+
+        update(generatedTestsTabData)
+    }
+
+    fun hideTestCase(testCaseName: String, generatedTestsTabData: GeneratedTestsTabData) {
+        generatedTestsTabData.hiddenTestCases.add(testCaseName)
+        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+            generatedTestsTabData.testsSelected--
+        }
+
+        update(generatedTestsTabData)
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -190,7 +190,10 @@ class GeneratedTestsTabBuilder(
     fun applyTests(): Boolean {
         // Filter the selected test cases
         val selectedTestCasePanels =
-            generatedTestsTabData.testCaseNameToPanel.filter { (it.value.getComponent(0) as JCheckBox).isSelected }
+            generatedTestsTabData.testCaseNameToPanel.filter {
+                val testIsNotHidden = !generatedTestsTabData.hiddenTestCases.contains(it.key)
+                (it.value.getComponent(0) as JCheckBox).isSelected && testIsNotHidden
+            }
         val selectedTestCases = selectedTestCasePanels.map { it.key }
 
         // Get the test case components (source code of the tests)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -161,7 +161,7 @@ class GeneratedTestsTabBuilder(
             testCasePanel.add(Box.createRigidArea(Dimension(12, 0)), BorderLayout.EAST)
 
             // Add panel to parent panel
-            testCasePanel.maximumSize = Dimension(Short.MAX_VALUE.toInt(), Short.MAX_VALUE.toInt())
+            testCasePanel.maximumSize = Dimension(Short.MAX_VALUE.toInt(), testCasePanel.preferredSize.height)
             generatedTestsTabData.allTestCasePanel.add(testCasePanel)
             addSeparator()
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -16,6 +16,7 @@ class GeneratedTestsTabData {
     val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
     var testsSelected: Int = 0
     val unselectedTestCases: HashMap<Int, TestCase> = HashMap()
+    val hiddenTestCases: HashMap<Int, TestCase> = HashMap()
     val testCasePanelFactories: ArrayList<TestCasePanelBuilder> = arrayListOf()
     var allTestCasePanel: JPanel = JPanel()
     val applyButton: JButton = JButton(PluginLabelsBundle.get("applyButton"))

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -16,7 +16,7 @@ class GeneratedTestsTabData {
     val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
     var testsSelected: Int = 0
     val unselectedTestCases: HashMap<Int, TestCase> = HashMap()
-    val hiddenTestCases: HashMap<Int, TestCase> = HashMap()
+    val hiddenTestCases: HashSet<String> = HashSet()
     val testCasePanelFactories: ArrayList<TestCasePanelBuilder> = arrayListOf()
     var allTestCasePanel: JPanel = JPanel()
     val applyButton: JButton = JButton(PluginLabelsBundle.get("applyButton"))

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -94,6 +94,7 @@ class TestCasePanelBuilder(
     private val dimensionSize = 7
 
     private var isRemoved = false
+    private var isShown = true
 
     // Add an editor to modify the test source code
     private val languageTextField = LanguageTextField(
@@ -661,6 +662,7 @@ class TestCasePanelBuilder(
     }
 
     private fun toggleTestCaseVisibility(visible: Boolean) {
+        isShown = visible
         val testCasePanel = generatedTestsTabData.testCaseNameToPanel[testCase.testName]!!
         if (visible) {
             testCasePanel.removeAll()
@@ -739,6 +741,7 @@ class TestCasePanelBuilder(
      * @return true if the item is removed, false otherwise.
      */
     fun isRemoved() = isRemoved
+    fun isShown() = isShown
 
     /**
      * Updates the current test case with the specified test name and test code.

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -669,10 +669,12 @@ class TestCasePanelBuilder(
             testCasePanel.add(getUpperPanel(), BorderLayout.NORTH)
             testCasePanel.add(getMiddlePanel(), BorderLayout.CENTER)
             testCasePanel.add(getBottomPanel(), BorderLayout.SOUTH)
+            ReportUpdater.addTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
         } else {
             testCasePanel.removeAll()
             val removedTestPanel = getRemovedTestPanel()
             testCasePanel.add(removedTestPanel)
+            ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
         }
         GenerateTestsTabHelper.update(generatedTestsTabData)
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -669,11 +669,16 @@ class TestCasePanelBuilder(
             testCasePanel.add(getUpperPanel(), BorderLayout.NORTH)
             testCasePanel.add(getMiddlePanel(), BorderLayout.CENTER)
             testCasePanel.add(getBottomPanel(), BorderLayout.SOUTH)
+
+            generatedTestsTabData.hiddenTestCases.remove(testCase.id)
             ReportUpdater.addTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
         } else {
             testCasePanel.removeAll()
             val removedTestPanel = getRemovedTestPanel()
             testCasePanel.add(removedTestPanel)
+
+            generatedTestsTabData.hiddenTestCases[testCase.id] = testCase
+            generatedTestsTabData.testsSelected--
             ReportUpdater.removeTestCase(report, testCase, coverageVisualisationTabBuilder, generatedTestsTabData)
         }
         GenerateTestsTabHelper.update(generatedTestsTabData)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -652,7 +652,10 @@ class TestCasePanelBuilder(
      * 3. Updating the UI.
      */
     private fun removePermanently() {
+        val indexOfSeparatorBelowTestCase =
+            generatedTestsTabData.allTestCasePanel.getComponentZOrder(hiddenTestCasePanel) + 1
         generatedTestsTabData.allTestCasePanel.remove(hiddenTestCasePanel)
+        generatedTestsTabData.allTestCasePanel.remove(indexOfSeparatorBelowTestCase)
 
         // Remove the test case from the cache
         GenerateTestsTabHelper.removeTestCase(testCase.testName, generatedTestsTabData)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
@@ -79,11 +79,15 @@ class TopButtonsPanelBuilder {
      *  @param selected whether the checkboxes have to be selected or not
      */
     private fun toggleAllCheckboxes(selected: Boolean, generatedTestsTabData: GeneratedTestsTabData) {
-        generatedTestsTabData.testCaseNameToPanel.forEach { (_, jPanel) ->
+        generatedTestsTabData.testCaseNameToPanel
+            .filter { it.key !in generatedTestsTabData.hiddenTestCases }
+            .forEach { (_, jPanel) ->
             val checkBox = jPanel.getComponent(0) as JCheckBox
             checkBox.isSelected = selected
         }
-        generatedTestsTabData.testsSelected = if (selected) generatedTestsTabData.testCaseNameToPanel.size else 0
+        generatedTestsTabData.testsSelected = if (selected){
+            generatedTestsTabData.testCaseNameToPanel.size - generatedTestsTabData.hiddenTestCases.size
+        } else 0
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
@@ -106,7 +106,7 @@ class TopButtonsPanelBuilder {
         val tasks: Queue<(CustomProgressIndicator) -> Unit> = LinkedList()
 
         for (testCasePanelFactory in generatedTestsTabData.testCasePanelFactories) {
-            testCasePanelFactory.addTask(tasks)
+            if (testCasePanelFactory.isShown()) testCasePanelFactory.addTask(tasks)
         }
         // run tasks one after each other
         executeTasks(project, tasks, generatedTestsTabData)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
@@ -50,16 +50,19 @@ class TopButtonsPanelBuilder {
             removeAllButton.doClick()
             return
         }
+
+        val numOfShownTests =
+            generatedTestsTabData.testCaseNameToPanel.size - generatedTestsTabData.hiddenTestCases.size
         testsSelectedLabel.text = String.format(
             testsSelectedText,
             generatedTestsTabData.testsSelected,
-            generatedTestsTabData.testCaseNameToPanel.size,
+            numOfShownTests,
         )
         testsPassedLabel.text =
             String.format(
                 testsPassedText,
                 passedTestsCount,
-                generatedTestsTabData.testCaseNameToPanel.size,
+                numOfShownTests,
             )
         runAllButton.isEnabled = false
         for (testCasePanelFactory in generatedTestsTabData.testCasePanelFactories) {

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/ReportUpdater.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/ReportUpdater.kt
@@ -29,6 +29,17 @@ object ReportUpdater {
         coverageVisualisationTabBuilder.show(report, generatedTestsTabData)
     }
 
+    fun addTestCase(
+        report: Report,
+        testCase: TestCase,
+        coverageVisualisationTabBuilder: CoverageVisualisationTabBuilder,
+        generatedTestsTabData: GeneratedTestsTabData,
+    ) {
+        report.testCaseList[testCase.id] = testCase
+        report.normalized()
+        coverageVisualisationTabBuilder.show(report, generatedTestsTabData)
+    }
+
     fun unselectTestCase(
         report: Report,
         unselectedTestCases: HashMap<Int, TestCase>,

--- a/src/main/resources/properties/plugin/PluginLabels.properties
+++ b/src/main/resources/properties/plugin/PluginLabels.properties
@@ -64,3 +64,6 @@ llmSetup=LLM Setup
 llmSampleSelectorFactory=Test Sample Provider for LLM
 provideTestSample=Provide test samples
 noTestSample=Do not provide any sample
+removedTestJLabel=This test was removed
+undoButtonLabel=Undo
+removeTestLabel=Remove permanently


### PR DESCRIPTION
# Description of changes made
Currently, users can delete generated test cases but there is no way to restore a test case deleted by accident. This PR implements the functionality for recovering a test case after its deletion. When the user deletes a test case, its UI gets swapped with `hiddenTestCasePanel` that displays a message indicating that the test is removed and two buttons: "Undo" and "Remove permanently". 

When a test case gets deleted, it is only hidden in the UI. However, its state is still kept in memory. This allows to restore the test case back with all user changes easily. This PR also contains changes to parts of the code responsible for displaying and managing the state of other UI components such as statistics in the top line, and checkboxes, and makes sure the "Select/Unselect all", "Run all", and "Apply to test suite" buttons apply only to visible tests.

![Image showcasing undo delete test functionality](https://github.com/user-attachments/assets/1a60f3f9-f0f3-4415-9ff4-0ce673ea90ac)

# Why is merge request needed
Closes #230 

# What is missing?
- When there are too few tests and they are all hidden, the list layout makes them occupy the whole possible height. The UI could be further improved to display elements more compactly, but it should be first agreed upon with designers and project maintainers.
- It would be good to test the provided functionality in an automated way.

- [x] I have checked that I am merging into correct branch
