### PR TITLE
Java path for kotlin tests compilation on Windows machines

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -13,12 +13,10 @@ class KotlinTestCompiler(
     libPaths: List<String>,
     junitLibPaths: List<String>,
     kotlinSDKHomeDirectory: String,
-    javaHomeDirectoryPath: String,
+    private val javaHomeDirectoryPath: String,
 ) : TestCompiler(libPaths, junitLibPaths) {
     private val logger = KotlinLogging.logger { this::class.java }
     private val kotlinc: String
-    // Direct declaration in constructor requires changes to TestCompiler, so we declare it here.
-    private val javaHomeDirectoryPath = javaHomeDirectoryPath
 
     // init block to find the kotlinc compiler
     init {
@@ -35,7 +33,6 @@ class KotlinTestCompiler(
                  * as failed compilation because `kotlinc` will complain about
                  * `java` command missing in PATH.
                  *
-                 * TODO(vartiukhov): find a way to locate `java` on Windows
                  */
                 val isCompilerName = if (DataFilesUtil.isWindows()) {
                     it.name.equals("kotlinc")

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
@@ -24,33 +24,41 @@ object TestCompilerFactory {
 
         // TODO add the warning window that for Java we always need the javaHomeDirectoryPath
         return when (language) {
-            SupportedLanguage.Java -> createJavaCompiler(project, libraryPaths, junitLibraryPaths, javaHomeDirectory)
-            SupportedLanguage.Kotlin -> createKotlinCompiler(libraryPaths, junitLibraryPaths)
+            SupportedLanguage.Java -> {
+                val javaSDKHomePath = findJavaSDKHomePath(javaHomeDirectory, project)
+                JavaTestCompiler(libraryPaths, junitLibraryPaths, javaSDKHomePath)
+            }
+            SupportedLanguage.Kotlin -> {
+                val javaSDKHomePath = findJavaSDKHomePath(javaHomeDirectory, project) // Kotlinc relies on java to compile kotlin files.
+                val kotlinSDKHomeDirectory = KotlinPluginLayout.kotlinc.absolutePath
+                KotlinTestCompiler(libraryPaths, junitLibraryPaths, kotlinSDKHomeDirectory, javaSDKHomePath)
+            }
         }
     }
 
-    private fun createJavaCompiler(
+    /**
+     * Finds the home path of the Java SDK.
+     *
+     * @param javaHomeDirectory The directory where Java SDK is installed. If null, the project's configured SDK path is used.
+     * @param project The project for which the Java SDK home path is being determined.
+     * @return The home path of the Java SDK.
+     * @throws JavaSDKMissingException If no Java SDK is configured for the project.
+     */
+    private fun findJavaSDKHomePath(
+        javaHomeDirectory: String?,
         project: Project,
-        libraryPaths: List<String>,
-        junitLibraryPaths: List<String>,
-        javaHomeDirectory: String? = null,
-    ): JavaTestCompiler {
-        val javaSDKHomePath = javaHomeDirectory
-            ?: ProjectRootManager.getInstance(project).projectSdk?.homeDirectory?.path
+    ): String {
+        val javaSDKHomePath =
+            javaHomeDirectory
+                ?: ProjectRootManager
+                    .getInstance(project)
+                    .projectSdk
+                    ?.homeDirectory
+                    ?.path
 
         if (javaSDKHomePath == null) {
             throw JavaSDKMissingException(LLMMessagesBundle.get("javaSdkNotConfigured"))
         }
-
-        return JavaTestCompiler(libraryPaths, junitLibraryPaths, javaSDKHomePath)
-    }
-
-    private fun createKotlinCompiler(
-        libraryPaths: List<String>,
-        junitLibraryPaths: List<String>,
-    ): KotlinTestCompiler {
-        // kotlinc should be under `[kotlinSDKHomeDirectory]/bin/kotlinc`
-        val kotlinSDKHomeDirectory = KotlinPluginLayout.kotlinc.absolutePath
-        return KotlinTestCompiler(libraryPaths, junitLibraryPaths, kotlinSDKHomeDirectory)
+        return javaSDKHomePath
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/factories/TestCompilerFactory.kt
@@ -29,7 +29,9 @@ object TestCompilerFactory {
                 JavaTestCompiler(libraryPaths, junitLibraryPaths, javaSDKHomePath)
             }
             SupportedLanguage.Kotlin -> {
-                val javaSDKHomePath = findJavaSDKHomePath(javaHomeDirectory, project) // Kotlinc relies on java to compile kotlin files.
+                // Kotlinc relies on java to compile kotlin files.
+                val javaSDKHomePath = findJavaSDKHomePath(javaHomeDirectory, project)
+                // kotlinc should be under `[kotlinSDKHomeDirectory]/bin/kotlinc`
                 val kotlinSDKHomeDirectory = KotlinPluginLayout.kotlinc.absolutePath
                 KotlinTestCompiler(libraryPaths, junitLibraryPaths, kotlinSDKHomeDirectory, javaSDKHomePath)
             }


### PR DESCRIPTION
In this merge request we are closing an issue where Windows users who did not have java in their PATH variable could not run the generated kotlin tests because `kotlinc` requires Java to be in the path variable.

# Description of changes made
To address this issue, I added the same Java Path, which is used by the `JavaTestCompiler` to the `KotlinTestCompiler` class. This required changing the `TestCompilerFacotry` to find the Java path and pass it to `KotlinTestCompiler`. I decided to remove dedicated functions for creating Kotlin and Java test compilers because I thought that now they are more similar than different. Instead, I added a private function for finding the Java home path. 

The `KotlinTestCompiler` now gets a `javaHomeDirectoryPath` which is not directly assigned in the constructor because that would require changing the `TestCompiler` class. I thought that `TestCompiler` class should not be dedicated to the Java / Kotlin language, hence I did not change it. 

The Java path is set only if we detect that the system is a Windows machine. It is set through a chain of commands via command prompt.

# Other notes
- [x] Please test that nothing broke on Mac with regard to Java- and Kotlin-based test case generation. Thanks!

# Why is merge request needed
Closes #410
Closes #320 

- [X] I have checked that I am merging into correct branch
