### PR TITLE
Update version of `grazie-test-generation` module to `1.0.9`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ val spacePassword =
     System.getProperty("space.pass")?.toString() ?: project.properties["spacePassword"]?.toString() ?: ""
 
 // the test generation module for interacting with Grazie (used when the space credentials are provided)
-val grazieTestGenerationVersion = "1.0.5"
+val grazieTestGenerationVersion = "1.0.9"
 
 plugins {
     // Java support


### PR DESCRIPTION
# Description of changes made
This version of the module introduces several Llama models.

Here are the new models (see this [PR](https://jetbrains.team/p/automatically-generating-unit-tests/reviews/229/timeline)):

![Screenshot 2024-12-03 at 20 42 10](https://github.com/user-attachments/assets/e0e90bae-304a-4a2d-9217-9d5ce34f1223)


# Other notes
Closes #419

- [x] I have checked that I am merging into correct branch
