### PR TITLE
Revive headless mode for IntelliJ 2024.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib/evosuite-*.jar
 lib/JUnitRunner.jar
 **/evosuite-tests/
 *.DS_Store
+.intellijPlatform
 
 # Test projects
 src/test/resources/project/.idea/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ repositories {
 }
 
 if (spaceCredentialsProvided()) {
+    println("WIth space creds!")
     // Add the new source set
     val hasGrazieAccess = sourceSets.create("hasGrazieAccess")
     // add output of main source set to new source set class path
@@ -155,7 +156,7 @@ dependencies {
         "hasGrazieAccessCompileOnly"(project(":core"))
     }
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.9.23")
 
     // https://central.sonatype.com/artifact/io.github.oshai/kotlin-logging-jvm/overview
     implementation("io.github.oshai:kotlin-logging-jvm:6.0.3")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
# Description of changes made
**This PR introduces an implementation of a `headless2` task that is runnable on a newer IntelliJ 2024.3**.

The exact setup:

1. IntelliJ version:
```
IntelliJ IDEA 2024.3
Build #JBC-243.21565.193, built on November 13, 2024
Licensed to JetBrains Team / Vladislav Artiukhov
You have a perpetual fallback license for this version.
Subscription is active until December 31, 2025.
Runtime version: 21.0.5+8-b631.16 x86_64 (JCEF 122.1.9)
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
Toolkit: sun.lwawt.macosx.LWCToolkit
macOS 14.2.1
Controller in Remote Development
GC: G1 Young Generation, G1 Concurrent GC, G1 Old Generation
Memory: 1500M
Cores: 16
Metal Rendering is ON
Registry:
  debugger.auto.attach.from.console=true
  ide.experimental.ui=true
  i18n.locale=
Non-Bundled Plugins:
  com.intellij.plugins.visualstudiokeymap (243.21565.122)
  com.intellij.plugins.netbeanskeymap (243.21565.122)
  com.intellij.plugins.eclipsekeymap (243.21565.122)
```

2. The machine on which I tested the `headless2` task:
```
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.3 LTS
Release:        22.04
Codename:       jammy
```

4. How to run and test (**I attached a zip with a sample project**):
```
./gradlew :headless2 -p "/path/to/project/folder/TestSpark" \
	-Proot="/path/to/sample-projects/hello-world-java" \
	-Pfile="src/main/java/hello/world/Calculator.java" \
	-Pcut="hello.world.Calculator" \
	-Pcp="/home/ubuntu/research-work-2024/sample-projects/hello-world-java/build/classes:/home/ubuntu/research-work-2024/sample-projects/hello-world-java/build/classes/java:/home/ubuntu/research-work-2024/sample-projects/hello-world-java/build/classes/java/main" \
	-Pjunitv="5" \
	-Pjavahome="/home/ubuntu/.gradle/jdks/adoptium-17-x64-hotspot-linux/jdk-17.0.10+7/bin/java (any >=17 fits)" \
	-Pllm="GPT-4o" \
	-Ptoken="Grazie Token" \
	-Pprompt="/path/to/prompt.txt" \
	-Pout="/path/to/out/folder" \
	-PenableCoverage="true" \
	-Dspace.username="Vladislav.Artiukhov" \
	-Dspace.pass="Space Token" \
	--stacktrace
```
Here is the sample project to test on:
[hello-world-java.zip](https://github.com/user-attachments/files/18000473/hello-world-java.zip)


# Other notes
**The PR is not for merging!** See below.

# What is missing?
The modifications are messy; I do not plan to merge the PR into development. The PR is opened as a draft to raise awareness of other folks.
