### PR TITLE
Update Kotlin and IJ versions range

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.9.0"
+    id("org.jetbrains.kotlin.jvm") version "2.1.0"
     // Gradle IntelliJ Plugin
     id("org.jetbrains.intellij.platform") version "2.1.0"
     // Gradle IntelliJ Plugin Migration Help (uncomment it for migration tips)
@@ -77,7 +77,6 @@ if (spaceCredentialsProvided()) {
 
     // Add the dependencies for the new source set
     dependencies {
-        add(hasGrazieAccess.implementationConfigurationName, kotlin("stdlib"))
         add(hasGrazieAccess.implementationConfigurationName, "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
         add(hasGrazieAccess.implementationConfigurationName, "org.jetbrains.research:grazie-test-generation:$grazieTestGenerationVersion")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,12 +10,12 @@ evosuiteVersion = 1.0.5
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 241
-pluginUntilBuild = 242.*
+pluginSinceBuild = 242
+pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2024.2.3
+platformVersion = 2024.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/test/kotlin/org/jetbrains/research/testspark/uiTest/utils/StepsLogger.kt
+++ b/src/test/kotlin/org/jetbrains/research/testspark/uiTest/utils/StepsLogger.kt
@@ -9,7 +9,8 @@ object StepsLogger {
     private var initializaed = false
 
     @JvmStatic
-    fun init() = synchronized(initializaed) {
+    private val lock = Any()
+    fun init() = synchronized(lock) {
         if (initializaed.not()) {
             StepWorker.registerProcessor(StepLogger())
             initializaed = true


### PR DESCRIPTION
# Description of changes made
This PR 

1- Update the IJ platform range.
2- The new platform has classes which has been compiled by Kotlin 2.1.0 so we also had to switch to this version. So, I changed the Kotlin version to `2.1.0` in `build.gradle.kts`. After this change, I had to also remove copy pasting kotlin-stdlib from `hasGrazieAccess` dependencies as the Gradle process was failing with the `stdlib already exists` error.
3- Updating the platform led to failing UI test. I also fixed this issue in [StepsLogger](https://github.com/JetBrains-Research/TestSpark/pull/421/files#diff-ab40be8e65b73557fe551359da4933b7d3c08cdbeda4942788438ae033ad061b).


I also installed the plugin manually on earlier versions, and it worked fine for me (screenshot attached).

<img width="1140" alt="image" src="https://github.com/user-attachments/assets/4990013d-7098-4a9a-a466-15db8a04aa62">

# Why is a merge request needed
To support new versions of IJ platforms

# Other notes
Closes #417 

- [x] I have checked that I am merging into correct branch
