### PR TITLE
Add K2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ TestSpark currently supports two test generation strategies:
     <p>For this type of test generation, TestSpark sends request to different Large Language Models. Also, it automatically checks if tests are valid before presenting it to users.</p>
     <p>This feature needs a token from OpenAI, HuggingFace, or the AI Assistant platform.</p>
     <ul>
-        <li>Supports Java (any version) and Kotlin (K2 mode should be disabled, checkout the Settings section on README).</li>
+        <li>Supports Java and Kotlin.</li>
         <li>Generates unit tests for capturing failures.</li>
         <li>Generate tests for Java classes, methods, and single lines.</li>
     </ul>
@@ -230,9 +230,6 @@ Or to a new file:
 
 ![Tests adding to a new file](readme-images/gifs/AddingToANewFile.gif#gh-light-mode-only)
 ![Tests adding to a new file_dark](readme-images/gifs/AddingToANewFile_dark.gif#gh-dark-mode-only)
-### Disable K2
-For LLM-based Kotlin test generation, you need to disable the K2 mode for now.
-![Disable K2 mode](readme-images/pngs/k2-mode/disable-k2.png)
 ### Settings
 <!-- How can users configure the plugin to match their needs? -->
 The plugin is configured mainly through the Settings menu. The plugin settings can be found under <kbd>Settings</kbd> > <kbd>Tools</kbd> > <kbd>TestSpark</kbd>. Here, the user is able to select options for the plugin:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,6 +255,12 @@ changelog {
 // }
 
 tasks {
+    // enable K2 mode in UI test
+    runIde {
+        jvmArgumentProviders += CommandLineArgumentProvider {
+            listOf("-Didea.kotlin.plugin.use.k2=true")
+        }
+    }
 
     compileKotlin {
         dependsOn("updateEvosuite")

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -187,6 +187,11 @@
         </extensionPoint>
     </extensionPoints>
 
+    <!-- This is a temporary mechanism to mark the plugin as K2 compatible. -->
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinPluginMode supportsK2="true"/>
+    </extensions>
+
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow id="TestSpark" secondary="true" anchor="right"
                     icon="org.jetbrains.research.testspark.display.TestSparkIcons.toolWindowIcon"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,7 +18,7 @@
     <p>For this type of test generation, TestSpark sends request to different Large Language Models. Also, it automatically checks if tests are valid before presenting it to users.</p>
     <p>This feature needs a token from OpenAI, HuggingFace, or the AI Assistant platform.</p>
     <ul>
-        <li>Supports Java (any version) and Kotlin (K2 mode should be disabled, checkout the Settings section on README).</li>
+        <li>Supports Java and Kotlin.</li>
         <li>Generates unit tests for capturing failures.</li>
         <li>Generate tests for Java classes, methods, and single lines.</li>
     </ul>


### PR DESCRIPTION
# Description of changes made
This PR enables Kotlin test generation when K2 mode is enabled.

# Other notes
Closes #422 

# What is missing?
The current mechanism to make a plugin K2 compatible is temporary and should be reviewed for the upcoming versions of the IJ platform


- [x] I have checked that I am merging into correct branch
