### PR TITLE
Update Java and IJ versions range

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ kexVersion = 0.0.8
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 242
-pluginUntilBuild = 243.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
@@ -23,7 +23,7 @@ platformVersion = 2024.3
 platformPlugins = com.intellij.java, org.jetbrains.kotlin, org.jetbrains.idea.maven, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 17 is required since 2023.1
-javaVersion = 17
+javaVersion = 21
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.10.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ platformVersion = 2024.3
 platformPlugins = com.intellij.java, org.jetbrains.kotlin, org.jetbrains.idea.maven, com.intellij.gradle
 
 # Java language level used to compile sources and to generate the files for - Java 17 is required since 2023.1
-javaVersion = 21
+javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 8.10.2

--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -55,8 +55,8 @@ class KotlinPsiClassWrapper(private val psiClass: KtClassOrObject) : PsiClassWra
                 // Resolve the superclass type reference to a KtClass
                 val superClassPsiClass = superClassEntry?.typeReference?.let { typeRef ->
                     analyze(typeRef) {
-                        val ktType = typeRef.getKtType()
-                        val superClassSymbol = ktType.expandedClassSymbol
+                        val ktType = typeRef.type
+                        val superClassSymbol = ktType.expandedSymbol
                         superClassSymbol?.psi as? KtClass
                     }
                 }


### PR DESCRIPTION
# Description of changes made
- Updated `pluginUntilBuild` property from `243.*` to `251.*`
- ~~Updated Java version from 17 to 21 because, [as stated in the docs](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html#platformVersions), plugins targeting IJ platform 2024.2+ must use Java 21~~
- Resolved deprecated API issues

# Why is merge request needed
IntelliJ Platform version 2025.1 is already available as an early access preview. We should update the version as soon as we can.

# What is missing?
`./gradlew verifyPluginStructure` task fails with the following error:
`[org.jetbrains.intellij.platform] The plugin descriptor 'plugin.xml' is not found.`

However, it currently fails with the same error on `development` branch as well and this issue is likely related to the task configuration, not to this PR.

- [X] I have checked that I am merging into correct branch
