### PR TITLE
Update README to also mention Google AI as an LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ TestSpark is a plugin for generating unit tests. TestSpark natively integrates d
 
 TestSpark currently supports two test generation strategies:
 <ul>
-        <li>LLM-based test generation (using <a href="https://openai.com">OpenAI</a>, HuggingFace, and JetBrains internal AI Assistant platform)</li>
+        <li>LLM-based test generation (using <a href="https://openai.com">OpenAI</a>, HuggingFace, <a href="https://ai.google/">Google AI</a>, and JetBrains internal AI Assistant platform)</li>
         <li>Local search-based test generation (using <a href="https://www.evosuite.org">EvoSuite</a>)</li>
 </ul>
 <h4>LLM-based test generation</h4>
     <p>For this type of test generation, TestSpark sends request to different Large Language Models. Also, it automatically checks if tests are valid before presenting it to users.</p>
-    <p>This feature needs a token from OpenAI, HuggingFace, or the AI Assistant platform.</p>
+    <p>This feature needs a token from OpenAI, HuggingFace, Google AI, or the AI Assistant platform.</p>
     <ul>
         <li>Supports Java and Kotlin.</li>
         <li>Generates unit tests for capturing failures.</li>


### PR DESCRIPTION
In https://github.com/JetBrains-Research/TestSpark/pull/416, we've added support also for Google's AI platform. Back then I forgot to also update the README accordingly.

# Description of changes made
Add reference to Google AI to the readme.

# Why is merge request needed
I forgot to adjust the README.md back in #416.

- [X] I have checked that I am merging into correct branch
