### PR TITLE
[GitHub] [JBRes-2860] Add GitHub action that checks PR title formatting

### DIFF
--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -1,0 +1,12 @@
+{
+  "CHECKS": {
+    "prefixes": [],
+    "regexp": "^\\[[^\\]]+\\] .+",
+    "regexpFlags": "i"
+  },
+  "MESSAGES": {
+    "success": "All OK: The PR title formatting is correct",
+    "failure": "Incorrect PR title formatting",
+    "notice": ""
+  }
+}

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -1,0 +1,37 @@
+name: "PR Title Checker"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.4.3
+        id: check
+        continue-on-error: true
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+
+      - name: Add comment to inform user about the incorrect PR title format
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: ${{ steps.check.outputs.success == 'false'}}
+        with:
+          header: 'PR Title Check'
+          recreate: true
+          message: |
+            ### 🚨 PR Title Needs Formatting
+            Please specify the modified module and, preferrably, include a GitHub or YouTrack issue that this PR closes in the title. By `module`, we mean any logical part of the project — it doesn’t have to be a Gradle module or anything like that.
+            Use the following format: `[<Module(s)>] and(or) [<ISSUE-ID>] brief title`. Examples:
+            * `[LLM] Add support for Google AI as an LLM`
+            * `[Build] Update IntelliJ Platform version`
+            * `[#290]` Fix bug with LLM response parsing`
+            * `[PromptBuilder] [JBRes-2860] Refactor the PromptBuilder component`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           git push --set-upstream origin $BRANCH
 
           gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
+            --title "[Release] Changelog update - \`$VERSION\`" \
             --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
             --base main \
             --head $BRANCH


### PR DESCRIPTION
# Description of changes made
Added a GitHub action that triggers when a pull request is opened and when any changes get applied to the PR title. It checks if the PR title follows the following regex pattern: `^\[[^\]]+\] .+` and if not, leaves the following comment:

### 🚨 PR Title Needs Formatting
Please specify the modified module and, preferrably, include a GitHub or YouTrack issue that this PR closes in the title. By `module`, we mean any logical part of the project — it doesn’t have to be a Gradle module or anything like that.
Use the following format: `[<Module(s)>] and(or) [<ISSUE-ID>] brief title`. Examples:
- `[LLM] Add support for Google AI as an LLM`
- `[Build] Update IntelliJ Platform version`
- `[#290]` Fix bug with LLM response parsing`
- `[PromptBuilder] [JBRes-2860] Refactor the PromptBuilder component`

It uses [PR Title Checker](https://github.com/marketplace/actions/pr-title-checker), which is a third-party GitHub action

### Besides
- Changed the `release.yml` action, which creates Pull Requests to the `main` branch upon release, to name PRs in the correct format.

# Other notes
- Closes [JBRes-2860](https://youtrack.jetbrains.com/issue/JBRes-2860)

- [X] I have checked that I am merging into correct branch
