### PR TITLE
[GitHub] Update issue templates to automatically add a label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report
 title: ''
-labels: 'type: bug'
+labels: 'bug'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/new-feature.md
+++ b/.github/ISSUE_TEMPLATE/new-feature.md
@@ -2,7 +2,7 @@
 name: New feature
 about: Create an issue for a new feature
 title: ''
-labels: 'type: enhancement'
+labels: 'new feature'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -2,7 +2,7 @@
 name: Refactoring
 about: Suggest refactoring of some code
 title: ''
-labels: 'type: refactoring'
+labels: 'refactoring'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/testing.md
+++ b/.github/ISSUE_TEMPLATE/testing.md
@@ -2,7 +2,7 @@
 name: Testing
 about: Suggest covering some code with tests
 title: ''
-labels: 'type: testing'
+labels: 'testing'
 assignees: ''
 
 ---


### PR DESCRIPTION
# Description of changes made
Currently the label is not added automatically for issues based on the template they were created from. So I corrected their configuration.

- [X] I have checked that I am merging into correct branch
