### PR TITLE
[#442] Add file name sanitization

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -42,13 +42,14 @@ class TestProcessor(
         }
         Path(generatedTestPath).createDirectories()
 
+        val testFilePath = "$generatedTestPath${sanitizeFileName(testFileName)}"
         // Save the generated test suite to the file
-        val testFile = File("$generatedTestPath$testFileName")
+        val testFile = File(testFilePath)
         testFile.createNewFile()
         log.info("Save test in file " + testFile.absolutePath)
         testFile.writeText(code)
 
-        return "$generatedTestPath$testFileName"
+        return testFilePath
     }
 
     /**
@@ -285,7 +286,8 @@ class TestProcessor(
                     }
                     children("sourcefile") {
                         isCorrectSourceFile =
-                            this.attributes.getValue("name") == projectContext.fileUrlAsString!!.split(File.separatorChar).last()
+                            this.attributes.getValue("name") == projectContext.fileUrlAsString!!.split(File.separatorChar)
+                                .last()
                         children("line") {
                             if (isCorrectSourceFile && this.attributes.getValue("mi") == "0") {
                                 setOfLines.add(this.attributes.getValue("nr").toInt())
@@ -319,5 +321,16 @@ class TestProcessor(
                 isJavaName && it.isFile
             }
             .first()
+    }
+
+    /**
+     * Remove all forbidden characters depending on platform.
+     */
+    private fun sanitizeFileName(name: String): String {
+        if (DataFilesUtil.isWindows()) {
+            val forbiddenChars = arrayOf("<", ">", ":", "\"", "/", "\\", "|", "?", "*")
+            return forbiddenChars.fold(name) { acc, c -> acc.replace(c, "_") }
+        }
+        return name
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -287,7 +287,7 @@ class TestProcessor(
                     children("sourcefile") {
                         isCorrectSourceFile =
                             this.attributes.getValue("name") == projectContext.fileUrlAsString!!.split(File.separatorChar)
-                                .last()
+                            .last()
                         children("line") {
                             if (isCorrectSourceFile && this.attributes.getValue("mi") == "0") {
                                 setOfLines.add(this.attributes.getValue("nr").toInt())


### PR DESCRIPTION
# Description of changes made

Sanitize filename before saving  a generated test.

# Why is merge request needed

The filename is created with the class name of the generated test. Even if i's not a good convention, a class name can contain forbidden characters on Windows like `"` if the name is written like this:

```kotlin
class `MyBadNameWithA""`
```



# Other notes
Closes #442

As far as I see, the only place we construct the full path for a generated test is inside the method `saveGeneratedTest` and then the program uses the return value of this function as a path for a test. So, it is safe to do the sanitization here. Please correct me if I'm wrong.

# What is missing?
*Please mention if anything is missing for this merge request, e.g you have decided to move something to the next merge request*

- [x] I have checked that I am merging into correct branch
