### PR TITLE
[383] Refactor type handling for parameter type resolution.

### DIFF
--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -17,9 +17,7 @@ import org.jetbrains.kotlin.idea.testIntegration.framework.KotlinPsiBasedTestFra
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
-import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.psi.allConstructors
 import org.jetbrains.research.testspark.core.data.ClassType
 import org.jetbrains.research.testspark.core.utils.kotlinImportPattern
@@ -118,28 +116,10 @@ class KotlinPsiClassWrapper(private val psiClass: KtClassOrObject) : PsiClassWra
         }
     }
 
-    override fun getInterestingPsiClassesWithQualifiedNames(
-        psiMethod: PsiMethodWrapper,
-    ): MutableSet<PsiClassWrapper> {
+    override fun getInterestingPsiClassesWithQualifiedNames(psiMethod: PsiMethodWrapper): MutableSet<PsiClassWrapper> {
         val interestingPsiClasses = mutableSetOf<PsiClassWrapper>()
         val method = psiMethod as KotlinPsiMethodWrapper
-
-        method.psiFunction.valueParameters.forEach { parameter ->
-            var typeElement = parameter.typeReference?.typeElement
-            if (typeElement is KtNullableType) {
-                typeElement = typeElement.innerType
-            }
-            if (typeElement is KtUserType) {
-                val psiClass =
-                    typeElement.referenceExpression
-                        ?.references
-                        ?.firstOrNull()
-                        ?.resolve()
-                if (psiClass is KtClass && psiClass.fqName != null && !psiClass.fqName.toString().startsWith("kotlin.")) {
-                    interestingPsiClasses.add(KotlinPsiClassWrapper(psiClass))
-                }
-            }
-        }
+        interestingPsiClasses.addAll(method.getInterestingPsiClassesWithQualifiedNames())
 
         interestingPsiClasses.add(this)
         return interestingPsiClasses


### PR DESCRIPTION
# Description of changes made

Updated parameter type resolution to retrieve the actual class of the type. The previous implementation always retrieves the class where the method belongs to. That's why we had the same class duplicate several times, like there #383.

This was caused by https://github.com/JetBrains-Research/TestSpark/blob/0b511622368494c065d3c744806882f90bdbb27a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt#L127-L128 and this method is probably incorrect too https://github.com/JetBrains-Research/TestSpark/blob/0b511622368494c065d3c744806882f90bdbb27a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiMethodWrapper.kt#L87-L88

When `PsiTreeUtil.getParentOfType` is call with a `KtTypeReferenceElement` from a `KtParameter`, the first `KtClass::class.java` in the tree is the class where the method belongs to.

I try to find another way to get the actual type. It's my first time using PSI, my solution is probably not perfect, and I perhaps missed some cases to get the actual class.

**Cases covered:**
- [x] Interface
- [x] Concrete class
- [x] Nullable

**Cases not covered:**
- [ ] Generic type for Collection (maybe to be fixed in another PR)


```kotlin
class MyClass(val myProp: Int)

fun myMethod(a: List<MyClass>)
```
In the code above, the parameter `a` will be skipped because the class retrieved is `kotlin.collections.List` and it's skipped by this filter `!psiClass.fqName.toString().startsWith("kotlin.")`. It might be interesting to keep the `MyClass` class as an `interestingPsiClass`. But maybe it's an improvement for another PR/issue.

# Why is merge request needed

It fixed #383 and fixed a bigger issue: Currently, the extension doesn't add the types of method parameters as it's supposed to. Unless I missed something.

# Other notes

Closes #383

# What is missing?
*Please mention if anything is missing for this merge request, e.g you have decided to move something to the next merge request*

- Constructors of class are not resolved.
- Generic are not resolved, can be interesting information to retrieve.

- [x] I have checked that I am merging into correct branch
