### PR TITLE
[chore] Add git blame ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Merge of #445 [Refactoring] Update ktlint and fix code formatting issues
+8dd4a1973dd88b16a6ef574513c43217a74aad3c
+


### PR DESCRIPTION
Since version 2.23, git blame allows to ignore certain commits, which is especially useful for large formatting changes, as we have here.  This requires you to set `git config blame.ignoreRevsFile .git-blame-ignore-revs` locally. GitHub automatically uses this file in its interface.

- [X] I have checked that I am merging into correct branch
