### PR TITLE
[#453] add kotlin constructors for llm generation

### DIFF
--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -35,6 +35,10 @@ class KotlinPsiClassWrapper(
 
     override val text: String? get() = psiClass.text
 
+    private val constructors: List<KotlinPsiMethodWrapper> get() =
+        (psiClass.primaryConstructor?.let { listOf(KotlinPsiMethodWrapper(it)) } ?: emptyList()) +
+            psiClass.secondaryConstructors.map { KotlinPsiMethodWrapper(it) }
+
     override val methods: List<PsiMethodWrapper>
         get() =
             psiClass.body
@@ -42,7 +46,7 @@ class KotlinPsiClassWrapper(
                 ?.filter { it.name != null }
                 ?.map { KotlinPsiMethodWrapper(it) } ?: emptyList()
 
-    override val allMethods: List<PsiMethodWrapper> get() = methods
+    override val allMethods: List<PsiMethodWrapper> get() = constructors + methods
 
     override val constructorSignatures: List<String> get() = psiClass.allConstructors.map { KotlinPsiMethodWrapper.buildSignature(it) }
 

--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiMethodWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiMethodWrapper.kt
@@ -164,7 +164,9 @@ class KotlinPsiMethodWrapper(
         fun buildSignature(function: KtFunction) =
             function.run {
                 val bodyStart = bodyExpression?.startOffsetInParent ?: textLength
-                text.substring(0, bodyStart).replace('\n', ' ').trim()
+                val prefix = if (this is KtPrimaryConstructor || this is KtSecondaryConstructor) name else ""
+                val signatureStart = if (this is KtSecondaryConstructor) "constructor".length else 0
+                prefix + text.substring(signatureStart, bodyStart).replace('\n', ' ').trim()
             }
     }
 }


### PR DESCRIPTION
# Description of changes made

Add primary and secondary constructors to method signatures for a class in Kotlin when generating a test using LLM.

# Why is merge request needed

In java, constructors are in the list of methods https://github.com/JetBrains-Research/TestSpark/blob/d341094c1c706b8c49b7973d759703bcb0c93dec/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt#L28

But in Kotlin, constructors are not in the list of functions https://github.com/JetBrains-Research/TestSpark/blob/d341094c1c706b8c49b7973d759703bcb0c93dec/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt#L38-L43

This PR adds primary and secondary constructors to the `allMethods` property of `KotlinPsiClassWrapper`. It also updates the signature string of constructors, adding class name in front of the list of parameters and remove "constructor" if it's a secondary constructor.

# Other notes

Closes #453

Source code: 
````kotlin
class MyClass(val param1: List<Int?>) {
    constructor(param1: List<Int>, a: Int): this(param1) {
    }
    fun helper(i: Int): Int {
        return i+1
    }
}

class FunnyCalculator(val utils: MyClass) {
    fun sum(a: Int, b:Int): Int {

        var sum = 0;
        for (i in a..b) {
            sum += i
        }
        return sum
    }
    fun my(a: MyClass, c: Int, d: Int? ): Int {
        return utils.helper(c)
    }
}
````


Before:
````
The source code of method under test is as follows:
```
fun my(a: MyClass, c: Int, d: Int? ): Int {
        return utils.helper(c)
    }
```

Here are some information about other methods and classes used by the class under test. Only use them for creating objects, not your own ideas.
=== methods in org.example.MyClass:
 - fun helper(i: Int): Int
=== methods in org.example.FunnyCalculator:
 - fun sum(a: Int, b:Int): Int
 - fun my(a: MyClass2, c: Int, d: Int? ): Int
````

After:
````
The source code of method under test is as follows:
```
fun my(a: MyClass, c: Int, d: Int? ): Int {
        return utils.helper(c)
    }
```

Here are some information about other methods and classes used by the class under test. Only use them for creating objects, not your own ideas.
=== methods in org.example.MyClass:
 - MyClass(val param1: List<Int?>)
 - MyClass(param1: List<Int>, a: Int): this(param1)
 - fun helper(i: Int): Int
=== methods in org.example.FunnyCalculator:
 - FunnyCalculator(val utils: MyClass)
 - fun sum(a: Int, b:Int): Int
 - fun my(a: MyClass2, c: Int, d: Int? ): Int
````


# What is missing?

- [x] I have checked that I am merging into correct branch
