### PR TITLE
[#243] Improve indicator management

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkAction.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkAction.kt
@@ -4,8 +4,10 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.actions.controllers.VisibilityController
+import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.display.TestSparkDisplayManager
 import org.jetbrains.research.testspark.langwrappers.PsiHelperProvider
 import org.jetbrains.research.testspark.tools.TestsExecutionResultManager
@@ -17,6 +19,15 @@ import org.jetbrains.research.testspark.tools.TestsExecutionResultManager
  * It creates a dialog wrapper and displays it when the associated action is performed.
  */
 class TestSparkAction : AnAction() {
+    // Visibility controller within the context of the action.
+    val visibilityController = VisibilityController()
+
+    // Controller responsible for managing the unit test generation process.
+    val indicatorController = IndicatorController()
+
+    // Manages error monitoring and handling
+    val errorMonitor: ErrorMonitor = DefaultErrorMonitor()
+
     /**
      * Handles the action performed event.
      *
@@ -29,8 +40,9 @@ class TestSparkAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         TestSparkActionWindow(
             e = e,
-            visibilityController = VisibilityController(),
-            testGenerationController = TestGenerationController(),
+            visibilityController = visibilityController,
+            indicatorController = indicatorController,
+            errorMonitor = errorMonitor,
             testSparkDisplayManager = TestSparkDisplayManager(),
             testsExecutionResultManager = TestsExecutionResultManager(),
         )

--- a/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkActionWindow.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkActionWindow.kt
@@ -15,6 +15,7 @@ import org.jetbrains.research.testspark.actions.llm.LLMSetupPanelBuilder
 import org.jetbrains.research.testspark.actions.template.PanelBuilder
 import org.jetbrains.research.testspark.bundles.plugin.PluginLabelsBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.test.data.CodeType
 import org.jetbrains.research.testspark.display.TestSparkDisplayManager
 import org.jetbrains.research.testspark.display.TestSparkIcons
@@ -45,7 +46,6 @@ import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JRadioButton
 import javax.swing.SwingConstants
-import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 /**
  * Class representing the TestSparkActionWindow.

--- a/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkActionWindow.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/actions/TestSparkActionWindow.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.FormBuilder
-import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.actions.controllers.VisibilityController
 import org.jetbrains.research.testspark.actions.evosuite.EvoSuitePanelBuilder
 import org.jetbrains.research.testspark.actions.llm.LLMSampleSelectorBuilder
@@ -45,6 +45,7 @@ import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JRadioButton
 import javax.swing.SwingConstants
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 /**
  * Class representing the TestSparkActionWindow.
@@ -54,7 +55,8 @@ import javax.swing.SwingConstants
 class TestSparkActionWindow(
     private val e: AnActionEvent,
     private val visibilityController: VisibilityController,
-    private val testGenerationController: TestGenerationController,
+    private val indicatorController: IndicatorController,
+    private val errorMonitor: ErrorMonitor,
     private val testSparkDisplayManager: TestSparkDisplayManager,
     private val testsExecutionResultManager: TestsExecutionResultManager,
 ) : JFrame("TestSpark") {
@@ -324,7 +326,7 @@ class TestSparkActionWindow(
     }
 
     private fun startUnitTestGenerationTool(tool: Tool) {
-        if (!testGenerationController.isGeneratorRunning(project)) {
+        if (!indicatorController.isGeneratorRunning(project)) {
             val testSamplesCode = llmSampleSelectorFactory.getTestSamplesCode()
 
             for ((codeType, button) in codeTypeButtons) {
@@ -337,7 +339,8 @@ class TestSparkActionWindow(
                                 caretOffset,
                                 fileUrl,
                                 testSamplesCode,
-                                testGenerationController,
+                                indicatorController,
+                                errorMonitor,
                                 testSparkDisplayManager,
                                 testsExecutionResultManager,
                             )
@@ -349,7 +352,8 @@ class TestSparkActionWindow(
                                 caretOffset,
                                 fileUrl,
                                 testSamplesCode,
-                                testGenerationController,
+                                indicatorController,
+                                errorMonitor,
                                 testSparkDisplayManager,
                                 testsExecutionResultManager,
                             )
@@ -361,7 +365,8 @@ class TestSparkActionWindow(
                                 caretOffset,
                                 fileUrl,
                                 testSamplesCode,
-                                testGenerationController,
+                                indicatorController,
+                                errorMonitor,
                                 testSparkDisplayManager,
                                 testsExecutionResultManager,
                             )

--- a/src/main/kotlin/org/jetbrains/research/testspark/actions/controllers/IndicatorController.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/actions/controllers/IndicatorController.kt
@@ -6,33 +6,19 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
-import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
-import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
 
 /**
  * Manager used for monitoring the unit test generation process.
  * It also limits TestSpark to generate tests only once at a time.
  */
-class TestGenerationController {
+class IndicatorController {
     var indicator: CustomProgressIndicator? = null
-
-    // errorMonitor is passed in many places in the project
-    // and reflects if any bug happened in the test generation process
-    val errorMonitor: ErrorMonitor = DefaultErrorMonitor()
 
     /**
      * Method to show notification that test generation is already running.
      */
     private fun showGenerationRunningNotification(project: Project) {
-        val terminateButton: AnAction =
-            object : AnAction("Terminate") {
-                override fun actionPerformed(e: AnActionEvent) {
-                    indicator?.stop()
-                    errorMonitor.notifyErrorOccurrence()
-                }
-            }
-
         val notification =
             NotificationGroupManager
                 .getInstance()
@@ -42,6 +28,14 @@ class TestGenerationController {
                     PluginMessagesBundle.get("alreadyRunningTextNotificationText"),
                     NotificationType.WARNING,
                 )
+
+        val terminateButton: AnAction =
+            object : AnAction(PluginMessagesBundle.get("terminateButtonText")) {
+                override fun actionPerformed(e: AnActionEvent) {
+                    indicator?.stop()
+                    notification.expire()
+                }
+            }
 
         notification.addAction(terminateButton)
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/data/UIContext.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/data/UIContext.kt
@@ -1,13 +1,14 @@
 package org.jetbrains.research.testspark.data
 
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.generation.llm.network.RequestManager
-import org.jetbrains.research.testspark.core.monitor.DefaultErrorMonitor
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 data class UIContext(
     val projectContext: ProjectContext,
     val testGenerationOutput: TestGenerationData,
     var requestManager: RequestManager? = null,
+    val indicatorController: IndicatorController,
     val errorMonitor: ErrorMonitor,
 )

--- a/src/main/kotlin/org/jetbrains/research/testspark/data/UIContext.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/data/UIContext.kt
@@ -9,5 +9,5 @@ data class UIContext(
     val projectContext: ProjectContext,
     val testGenerationOutput: TestGenerationData,
     var requestManager: RequestManager? = null,
-    val errorMonitor: ErrorMonitor = DefaultErrorMonitor(),
+    val errorMonitor: ErrorMonitor,
 )

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/custom/IJProgressIndicator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/custom/IJProgressIndicator.kt
@@ -29,14 +29,20 @@ class IJProgressIndicator(
     override fun isRunning(): Boolean = indicator.isRunning
 
     override fun start() {
-        indicator.start()
+        if (!indicator.isRunning) {
+            indicator.start()
+        }
     }
 
     override fun stop() {
-        indicator.stop()
+        if (indicator.isRunning) {
+            indicator.stop()
+        }
     }
 
     override fun cancel() {
-        indicator.cancel()
+        if (!indicator.isCanceled) {
+            indicator.cancel()
+        }
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -39,7 +39,7 @@ class GeneratedTestsTabBuilder(
     private val testsExecutionResultManager: TestsExecutionResultManager,
     private val generationTool: GenerationTool,
 ) {
-    private val generatedTestsTabData: GeneratedTestsTabData = GeneratedTestsTabData()
+    private val generatedTestsTabData: GeneratedTestsTabData = GeneratedTestsTabData(uiContext.indicatorController)
 
     private var mainPanel: JPanel = JPanel()
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -4,13 +4,16 @@ import com.intellij.ui.EditorTextField
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentManager
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.bundles.plugin.PluginLabelsBundle
 import org.jetbrains.research.testspark.core.data.TestCase
 import javax.swing.JButton
 import javax.swing.JCheckBox
 import javax.swing.JPanel
 
-class GeneratedTestsTabData {
+class GeneratedTestsTabData(
+    val indicatorController: IndicatorController,
+) {
     val testCaseNameToPanel: HashMap<String, JPanel> = HashMap()
     val testCaseNameToSelectedCheckbox: HashMap<String, JCheckBox> = HashMap()
     val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -88,7 +88,7 @@ class TestCasePanelBuilder(
     private val testCase: TestCase,
     editor: Editor,
     private val checkbox: JCheckBox,
-    val uiContext: UIContext?,
+    val uiContext: UIContext,
     val report: Report,
     private val coverageVisualisationTabBuilder: CoverageVisualisationTabBuilder,
     private val generatedTestsTabData: GeneratedTestsTabData,
@@ -521,7 +521,9 @@ class TestCasePanelBuilder(
                 object : Task.Backgroundable(project, PluginMessagesBundle.get("sendingFeedback")) {
                     override fun run(indicator: ProgressIndicator) {
                         val ijIndicator = IJProgressIndicator(indicator)
-                        if (ToolUtils.isProcessStopped(uiContext!!.errorMonitor, ijIndicator)) {
+                        uiContext.indicatorController.activeIndicators.add(ijIndicator)
+
+                        if (ToolUtils.isProcessStopped(uiContext.errorMonitor, ijIndicator)) {
                             finishProcess()
                             return
                         }
@@ -564,6 +566,7 @@ class TestCasePanelBuilder(
 
                                 finishProcess()
                                 ijIndicator.stop()
+                                uiContext.indicatorController.activeIndicators.remove(ijIndicator)
                             }
                         }
                     }
@@ -572,7 +575,7 @@ class TestCasePanelBuilder(
     }
 
     private fun finishProcess(enableGlobal: Boolean = true) {
-        uiContext!!.errorMonitor.clear()
+        uiContext.errorMonitor.clear()
         loadingLabel.isVisible = false
         if (enableGlobal) enableGlobalComponents(true)
         enableLocalComponents(true)
@@ -594,7 +597,7 @@ class TestCasePanelBuilder(
     }
 
     private fun addTest(testSuite: TestSuiteGeneratedByLLM) {
-        val testSuitePresenter = JUnitTestSuitePresenter(project, uiContext!!.testGenerationOutput, language)
+        val testSuitePresenter = JUnitTestSuitePresenter(project, uiContext.testGenerationOutput, language)
 
         WriteCommandAction.runWriteCommandAction(project) {
             uiContext.errorMonitor.clear()
@@ -688,7 +691,7 @@ class TestCasePanelBuilder(
                     testCase.id,
                     testCase.testName,
                     testCase.testCode,
-                    uiContext!!.testGenerationOutput.packageName,
+                    uiContext.testGenerationOutput.packageName,
                     uiContext.testGenerationOutput.resultPath,
                     uiContext.projectContext,
                     testCompiler,

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
@@ -135,7 +135,12 @@ class TopButtonsPanelBuilder {
 
                     override fun run(indicator: ProgressIndicator) {
                         globalIndicator = indicator
-                        task(IJProgressIndicator(indicator))
+
+                        val ijIndicator = IJProgressIndicator(indicator)
+
+                        generatedTestsTabData.indicatorController.activeIndicators.add(ijIndicator)
+
+                        task(ijIndicator)
                     }
 
                     override fun onFinished() {

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import org.jetbrains.research.testspark.actions.controllers.IndicatorController
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
@@ -17,7 +18,6 @@ import org.jetbrains.research.testspark.tools.TestsExecutionResultManager
 import org.jetbrains.research.testspark.tools.evosuite.generation.EvoSuiteProcessManager
 import org.jetbrains.research.testspark.tools.template.Tool
 import java.io.File
-import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 /**
  * Represents the EvoSuite class, which is a tool used to generate tests for Java code.

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/EvoSuite.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
-import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
@@ -17,6 +17,7 @@ import org.jetbrains.research.testspark.tools.TestsExecutionResultManager
 import org.jetbrains.research.testspark.tools.evosuite.generation.EvoSuiteProcessManager
 import org.jetbrains.research.testspark.tools.template.Tool
 import java.io.File
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 /**
  * Represents the EvoSuite class, which is a tool used to generate tests for Java code.
@@ -62,7 +63,8 @@ class EvoSuite(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
@@ -72,7 +74,8 @@ class EvoSuite(
             psiHelper,
             caretOffset,
             fileUrl,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
         ).runTestGeneration(
@@ -98,7 +101,8 @@ class EvoSuite(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
@@ -109,7 +113,8 @@ class EvoSuite(
             psiHelper,
             caretOffset,
             fileUrl,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
         ).runTestGeneration(
@@ -136,7 +141,8 @@ class EvoSuite(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
@@ -147,7 +153,8 @@ class EvoSuite(
             psiHelper,
             caretOffset,
             fileUrl,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
         ).runTestGeneration(
@@ -179,7 +186,8 @@ class EvoSuite(
         psiHelper: PsiHelper,
         caretOffset: Int,
         fileUrl: String?,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ): Pipeline {
@@ -199,7 +207,8 @@ class EvoSuite(
             caretOffset,
             fileUrl,
             packageName,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
             name,

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/generation/EvoSuiteProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/evosuite/generation/EvoSuiteProcessManager.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Key
 import org.evosuite.utils.CompactReport
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.bundles.evosuite.EvoSuiteDefaultsBundle
 import org.jetbrains.research.testspark.bundles.evosuite.EvoSuiteMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
@@ -78,6 +79,7 @@ class EvoSuiteProcessManager(
         packageName: String,
         projectContext: ProjectContext,
         generatedTestsData: TestGenerationData,
+        indicatorController: IndicatorController,
         errorMonitor: ErrorMonitor,
         testsExecutionResultManager: TestsExecutionResultManager,
     ): UIContext? {
@@ -251,6 +253,7 @@ class EvoSuiteProcessManager(
             projectContext,
             generatedTestsData,
             StandardRequestManagerFactory(project).getRequestManager(project),
+            indicatorController,
             errorMonitor,
         )
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/kex/Kex.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/kex/Kex.kt
@@ -4,7 +4,8 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
-import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
@@ -56,7 +57,8 @@ class Kex(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
@@ -66,7 +68,8 @@ class Kex(
             psiHelper,
             caretOffset,
             fileUrl,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
         ).runTestGeneration(
@@ -83,7 +86,8 @@ class Kex(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
@@ -94,7 +98,8 @@ class Kex(
             psiHelper,
             caretOffset,
             fileUrl,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
         ).runTestGeneration(
@@ -116,7 +121,8 @@ class Kex(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
@@ -143,7 +149,8 @@ class Kex(
         psiHelper: PsiHelper,
         caretOffset: Int,
         fileUrl: String?,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ): Pipeline {
@@ -163,7 +170,8 @@ class Kex(
             caretOffset,
             fileUrl,
             packageName,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
             name,

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/kex/generation/KexProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/kex/generation/KexProcessManager.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.util.Key
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.bundles.kex.KexDefaultsBundle
 import org.jetbrains.research.testspark.bundles.kex.KexMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
@@ -81,6 +82,7 @@ class KexProcessManager(
         packageName: String,
         projectContext: ProjectContext,
         generatedTestsData: TestGenerationData,
+        indicatorController: IndicatorController,
         errorMonitor: ErrorMonitor,
         testsExecutionResultManager: TestsExecutionResultManager,
     ): UIContext? {
@@ -155,6 +157,7 @@ class KexProcessManager(
             projectContext,
             generatedTestsData,
             StandardRequestManagerFactory(project).getRequestManager(project),
+            indicatorController,
             errorMonitor,
         )
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -5,7 +5,7 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
-import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.core.exception.TestSparkException
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
@@ -22,6 +22,7 @@ import org.jetbrains.research.testspark.tools.llm.generation.LLMProcessManager
 import org.jetbrains.research.testspark.tools.llm.generation.PromptManager
 import org.jetbrains.research.testspark.tools.template.Tool
 import java.nio.file.Path
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 /**
  * The Llm class represents a tool called "Llm" that is used to generate tests for Java code.
@@ -82,13 +83,14 @@ class Llm(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
         log.info("Generation of tests for CLASS was selected")
-        if (!LLMHelper.isCorrectToken(project, testGenerationController.errorMonitor)) {
-            testGenerationController.finished()
+        if (!LLMHelper.isCorrectToken(project, errorMonitor)) {
+            indicatorController.finished()
             return
         }
         val codeType = FragmentToTestData(CodeType.CLASS)
@@ -99,7 +101,8 @@ class Llm(
             caretOffset,
             fileUrl,
             testSamplesCode,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
             codeType,
@@ -121,13 +124,14 @@ class Llm(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
         log.info("Generation of tests for METHOD was selected")
-        if (!LLMHelper.isCorrectToken(project, testGenerationController.errorMonitor)) {
-            testGenerationController.finished()
+        if (!LLMHelper.isCorrectToken(project, errorMonitor)) {
+            indicatorController.finished()
             return
         }
         val psiMethod = psiHelper.getSurroundingMethod(caretOffset)!!
@@ -139,7 +143,8 @@ class Llm(
             caretOffset,
             fileUrl,
             testSamplesCode,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
             codeType,
@@ -161,13 +166,14 @@ class Llm(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     ) {
         log.info("Generation of tests for LINE was selected")
-        if (!LLMHelper.isCorrectToken(project, testGenerationController.errorMonitor)) {
-            testGenerationController.finished()
+        if (!LLMHelper.isCorrectToken(project, errorMonitor)) {
+            indicatorController.finished()
             return
         }
         val selectedLine: Int = psiHelper.getSurroundingLineNumber(caretOffset)!!
@@ -179,7 +185,8 @@ class Llm(
             caretOffset,
             fileUrl,
             testSamplesCode,
-            testGenerationController,
+            indicatorController,
+            errorMonitor,
             testSparkDisplayManager,
             testsExecutionResultManager,
             codeType,
@@ -199,7 +206,7 @@ class Llm(
      * @param caretOffset The offset of the caret position in the PSI file.
      * @param fileUrl The URL of the file to generate tests for (optional).
      * @param testSamplesCode The code of the test samples to use for test generation.
-     * @param testGenerationController The controller for test generation operations.
+     * @param indicatorController The controller for test generation operations.
      * @param testSparkDisplayManager The manager for displaying test-related information.
      * @param testsExecutionResultManager The manager for handling test execution results.
      * @param codeType The type of data fragment to generate tests for.
@@ -210,7 +217,8 @@ class Llm(
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
         codeType: FragmentToTestData,
@@ -224,7 +232,8 @@ class Llm(
                     caretOffset,
                     fileUrl,
                     packageName,
-                    testGenerationController,
+                    indicatorController,
+                    errorMonitor,
                     testSparkDisplayManager,
                     testsExecutionResultManager,
                     name,
@@ -240,7 +249,7 @@ class Llm(
 
             pipeline.runTestGeneration(manager, codeType)
         } catch (err: TestSparkException) {
-            testGenerationController.finished()
+            indicatorController.finished()
             project.createNotification(err, NotificationType.ERROR)
         }
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/Llm.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.core.exception.TestSparkException
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.core.test.data.CodeType
 import org.jetbrains.research.testspark.data.FragmentToTestData
@@ -22,7 +23,6 @@ import org.jetbrains.research.testspark.tools.llm.generation.LLMProcessManager
 import org.jetbrains.research.testspark.tools.llm.generation.PromptManager
 import org.jetbrains.research.testspark.tools.template.Tool
 import java.nio.file.Path
-import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 
 /**
  * The Llm class represents a tool called "Llm" that is used to generate tests for Java code.

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/LLMProcessManager.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.bundles.llm.LLMMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.core.data.TestGenerationData
@@ -93,6 +94,7 @@ class LLMProcessManager(
         packageName: String,
         projectContext: ProjectContext,
         generatedTestsData: TestGenerationData,
+        indicatorController: IndicatorController,
         errorMonitor: ErrorMonitor,
         testsExecutionResultManager: TestsExecutionResultManager,
     ): UIContext? {
@@ -248,6 +250,6 @@ class LLMProcessManager(
             language,
         )
 
-        return UIContext(projectContext, generatedTestsData, requestManager, errorMonitor)
+        return UIContext(projectContext, generatedTestsData, requestManager, indicatorController, errorMonitor)
     }
 }

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/template/Tool.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/template/Tool.kt
@@ -2,7 +2,8 @@ package org.jetbrains.research.testspark.tools.template
 
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
-import org.jetbrains.research.testspark.actions.controllers.TestGenerationController
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
+import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.test.SupportedLanguage
 import org.jetbrains.research.testspark.display.TestSparkDisplayManager
 import org.jetbrains.research.testspark.langwrappers.PsiHelper
@@ -32,7 +33,8 @@ interface Tool {
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     )
@@ -52,7 +54,8 @@ interface Tool {
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     )
@@ -75,7 +78,8 @@ interface Tool {
         caretOffset: Int,
         fileUrl: String?,
         testSamplesCode: String,
-        testGenerationController: TestGenerationController,
+        indicatorController: IndicatorController,
+        errorMonitor: ErrorMonitor,
         testSparkDisplayManager: TestSparkDisplayManager,
         testsExecutionResultManager: TestsExecutionResultManager,
     )

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/template/generation/ProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/template/generation/ProcessManager.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.research.testspark.tools.template.generation
 
+import org.jetbrains.research.testspark.actions.controllers.IndicatorController
 import org.jetbrains.research.testspark.core.data.TestGenerationData
 import org.jetbrains.research.testspark.core.monitor.ErrorMonitor
 import org.jetbrains.research.testspark.core.progress.CustomProgressIndicator
@@ -25,6 +26,7 @@ interface ProcessManager {
         packageName: String,
         projectContext: ProjectContext,
         generatedTestsData: TestGenerationData,
+        indicatorController: IndicatorController,
         errorMonitor: ErrorMonitor,
         testsExecutionResultManager: TestsExecutionResultManager,
     ): UIContext?

--- a/src/main/resources/properties/plugin/PluginMessages.properties
+++ b/src/main/resources/properties/plugin/PluginMessages.properties
@@ -23,6 +23,7 @@ confirmationTitle=Are You Sure?
 !RunnerService
 alreadyRunningNotificationTitle=Generation is already running
 alreadyRunningTextNotificationText=You can generate more tests after the current test generation is complete.
+terminateButtonText=Terminate
 !Test case copied
 testCaseCopied=Test case copied
 !Build error messages

--- a/src/main/resources/properties/plugin/PluginMessages.properties
+++ b/src/main/resources/properties/plugin/PluginMessages.properties
@@ -21,9 +21,9 @@ generationWindowWarningMessage=TestSpark window is already active
 removeAllMessage=Are you sure you want to remove all tests?\nThis action cannot be undone
 confirmationTitle=Are You Sure?
 !RunnerService
-alreadyRunningNotificationTitle=Generation is already running
-alreadyRunningTextNotificationText=You can generate more tests after the current test generation is complete.
-terminateButtonText=Terminate
+alreadyRunningNotificationTitle=TestSpark executions are already running
+alreadyRunningTextNotificationText=You can generate more tests after the current executions are complete.
+terminateButtonText=Terminate all current executions
 !Test case copied
 testCaseCopied=Test case copied
 !Build error messages


### PR DESCRIPTION
# Description of changes made

Fixing several indicator issues:

- separate `indicatorController` and `errorMonitor`
- make these variables global for all TestSpark runs, because indicator memory cleans after each iteration
- collect mutiple indicators, not only one due to parallelism of the program
- collect indicators from all processes of the application, because each of them can go with a new test generation

How to reproduce:

- run test generation
- run the secaons round of test generation before tests visualisation from the first iteration
- run "Run all tests" or any other execution (request sending or run a single test)
- during this execution run the new iteration of test generation

# Other notes
Closes #243

- [x] I have checked that I am merging into correct branch
