### PR TITLE
[#276] Update thread management in the `returnOriginalEditorBackground` method

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
@@ -8,6 +8,9 @@ import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.ex.EditorGutterComponentEx
 import com.intellij.openapi.editor.markup.ActiveGutterRenderer
 import com.intellij.openapi.editor.markup.LineMarkerRendererEx
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.EditorTextField
@@ -18,6 +21,8 @@ import com.intellij.ui.components.ActionLink
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.FormBuilder
+import org.jetbrains.research.testspark.bundles.plugin.PluginDefaultsBundle
+import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginSettingsBundle
 import org.jetbrains.research.testspark.display.generatedTests.GeneratedTestsTabData
 import org.jetbrains.research.testspark.services.EvoSuiteSettingsService
@@ -56,6 +61,8 @@ class CoverageRenderer(
         get() = project.getService(EvoSuiteSettingsService::class.java).state
 
     private var defaultEditorColor: Color? = null
+
+    private val editorLock = Any()
 
     /**
      * Perform the action - show toolTip on mouse click.
@@ -179,7 +186,7 @@ class CoverageRenderer(
         if (editorTextField.background.equals(highlightColor)) return
         defaultEditorColor = editorTextField.background
         editorTextField.background = highlightColor
-        returnOriginalEditorBackground(editorTextField)
+        returnOriginalEditorBackground(editorTextField, name)
     }
 
     /**
@@ -219,12 +226,30 @@ class CoverageRenderer(
      * Reset the provided editors color to the default (initial) one after 10 seconds
      * @param editor the editor whose color to change
      */
-    private fun returnOriginalEditorBackground(editor: EditorTextField) {
-        Thread {
-            val timeWithHighlightedBackground: Long = 10000
-            Thread.sleep(timeWithHighlightedBackground)
-            editor.background = defaultEditorColor
-        }.start()
+    private fun returnOriginalEditorBackground(
+        editor: EditorTextField,
+        name: String,
+    ) {
+        ProgressManager.getInstance().run(
+            object : Task.Backgroundable(project, "${PluginMessagesBundle.get("coverageMessage")} $name") {
+                override fun run(indicator: ProgressIndicator) {
+                    val timeWithHighlightedBackground: Long =
+                        PluginDefaultsBundle.get("testCaseHighlightingDurationMs").toLong()
+                    val numberOfIterations = 100
+                    repeat(numberOfIterations) {
+                        if (indicator.isCanceled) return
+                        Thread.sleep(timeWithHighlightedBackground / numberOfIterations)
+                    }
+                }
+
+                override fun onFinished() {
+                    super.onFinished()
+                    synchronized(editorLock) {
+                        editor.background = defaultEditorColor
+                    }
+                }
+            },
+        )
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
@@ -34,6 +34,7 @@ import java.awt.Graphics
 import java.awt.Rectangle
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
+import org.jetbrains.research.testspark.display.custom.IJProgressIndicator
 
 /**
  * This class extends the line marker and gutter editor to allow more functionality.
@@ -233,6 +234,7 @@ class CoverageRenderer(
         ProgressManager.getInstance().run(
             object : Task.Backgroundable(project, "${PluginMessagesBundle.get("coverageMessage")} $name") {
                 override fun run(indicator: ProgressIndicator) {
+                    generatedTestsTabData.indicatorController.activeIndicators.add(IJProgressIndicator(indicator))
                     val timeWithHighlightedBackground: Long =
                         PluginDefaultsBundle.get("testCaseHighlightingDurationMs").toLong()
                     val numberOfIterations = 100

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
@@ -24,6 +24,7 @@ import com.intellij.util.ui.FormBuilder
 import org.jetbrains.research.testspark.bundles.plugin.PluginDefaultsBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginMessagesBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginSettingsBundle
+import org.jetbrains.research.testspark.display.custom.IJProgressIndicator
 import org.jetbrains.research.testspark.display.generatedTests.GeneratedTestsTabData
 import org.jetbrains.research.testspark.services.EvoSuiteSettingsService
 import org.jetbrains.research.testspark.services.PluginSettingsService
@@ -34,7 +35,6 @@ import java.awt.Graphics
 import java.awt.Rectangle
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
-import org.jetbrains.research.testspark.display.custom.IJProgressIndicator
 
 /**
  * This class extends the line marker and gutter editor to allow more functionality.

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
@@ -63,8 +63,6 @@ class CoverageRenderer(
 
     private var defaultEditorColor: Color? = null
 
-    private val editorLock = Any()
-
     /**
      * Perform the action - show toolTip on mouse click.
      *
@@ -246,7 +244,7 @@ class CoverageRenderer(
 
                 override fun onFinished() {
                     super.onFinished()
-                    synchronized(editorLock) {
+                    synchronized(this) {
                         editor.background = defaultEditorColor
                     }
                 }

--- a/src/main/resources/properties/plugin/PluginDefaults.properties
+++ b/src/main/resources/properties/plugin/PluginDefaults.properties
@@ -2,5 +2,6 @@ showCoverageCheckboxSelected=true
 colorRed=100
 colorGreen=150
 colorBlue=20
+testCaseHighlightingDurationMs=10000
 buildPath=
 buildCommand=

--- a/src/main/resources/properties/plugin/PluginMessages.properties
+++ b/src/main/resources/properties/plugin/PluginMessages.properties
@@ -1,6 +1,7 @@
 name=My Plugin
 !Indicator names
 testGenerationMessage=Generating tests
+coverageMessage=Highlighting of covered method
 buildMessage=Building project
 searchMessage=Generating tests
 generatingTestNumber=Generating test #


### PR DESCRIPTION
# Description of changes made
Improved the thread management in the `returnOriginalEditorBackground` method by adding ProgressManager instance; and processing the indicator cancellation. 

# Other notes
Closes #276 

- [x] I have checked that I am merging into correct branch
