### PR TITLE
[#368] update test case mapping to use IDs instead of names

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/TestSparkDisplayManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/TestSparkDisplayManager.kt
@@ -76,7 +76,7 @@ class TestSparkDisplayManager {
         // removing all tests
         generatedTestsTabBuilder!!.getRemoveAllButton().addActionListener {
             // in case of empty list -- just call clear method
-            if (generatedTestsTabBuilder!!.generatedTestsTabData().testCaseNameToPanel.isEmpty()) {
+            if (generatedTestsTabBuilder!!.generatedTestsTabData().testCaseIdToPanel.isEmpty()) {
                 clear()
                 return@addActionListener
             }

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
@@ -19,6 +19,7 @@ import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.util.ui.FormBuilder
 import org.jetbrains.research.testspark.bundles.plugin.PluginSettingsBundle
+import org.jetbrains.research.testspark.core.data.TestCase
 import org.jetbrains.research.testspark.display.generatedTests.GeneratedTestsTabData
 import org.jetbrains.research.testspark.services.EvoSuiteSettingsService
 import org.jetbrains.research.testspark.services.PluginSettingsService
@@ -29,7 +30,6 @@ import java.awt.Graphics
 import java.awt.Rectangle
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
-import org.jetbrains.research.testspark.core.data.TestCase
 
 /**
  * This class extends the line marker and gutter editor to allow more functionality.

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
@@ -186,7 +186,7 @@ class CoverageRenderer(
         if (editorTextField.background.equals(highlightColor)) return
         defaultEditorColor = editorTextField.background
         editorTextField.background = highlightColor
-        returnOriginalEditorBackground(editorTextField, name)
+        returnOriginalEditorBackground(editorTextField, id)
     }
 
     /**
@@ -228,10 +228,10 @@ class CoverageRenderer(
      */
     private fun returnOriginalEditorBackground(
         editor: EditorTextField,
-        name: String,
+        id: Int,
     ) {
         ProgressManager.getInstance().run(
-            object : Task.Backgroundable(project, "${PluginMessagesBundle.get("coverageMessage")} $name") {
+            object : Task.Backgroundable(project, "${PluginMessagesBundle.get("coverageMessage")} $id") {
                 override fun run(indicator: ProgressIndicator) {
                     generatedTestsTabData.indicatorController.activeIndicators.add(IJProgressIndicator(indicator))
                     val timeWithHighlightedBackground: Long =

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageRenderer.kt
@@ -29,6 +29,7 @@ import java.awt.Graphics
 import java.awt.Rectangle
 import java.awt.event.MouseEvent
 import javax.swing.JPanel
+import org.jetbrains.research.testspark.core.data.TestCase
 
 /**
  * This class extends the line marker and gutter editor to allow more functionality.
@@ -44,10 +45,10 @@ import javax.swing.JPanel
 class CoverageRenderer(
     private val color: Color,
     private val lineNumber: Int,
-    private val tests: List<String>,
+    private val tests: List<TestCase>,
     private val coveredMutation: List<String>,
     private val notCoveredMutation: List<String>,
-    private val mapMutantsToTests: HashMap<String, MutableList<String>>,
+    private val mapMutantsToTests: HashMap<String, MutableList<Int>>,
     private val project: Project,
     private val generatedTestsTabData: GeneratedTestsTabData,
 ) : ActiveGutterRenderer,
@@ -73,10 +74,10 @@ class CoverageRenderer(
                 .createFormBuilder()
                 .addComponent(JBLabel(" Covered by tests:"), 10)
 
-        for (testName in tests) {
+        for (testCase in tests) {
             prePanel.addComponent(
-                ActionLink(testName) {
-                    highlightTestCase(testName)
+                ActionLink(testCase.testName) {
+                    highlightTestCase(testCase.id)
                 },
             )
         }
@@ -149,7 +150,7 @@ class CoverageRenderer(
      */
     private fun highlightMutantsInToolwindow(
         mutantName: String,
-        map: HashMap<String, MutableList<String>>,
+        map: HashMap<String, MutableList<Int>>,
     ) {
         highlightCoveredMutants(map.getOrPut(mutantName) { ArrayList() })
     }
@@ -157,14 +158,14 @@ class CoverageRenderer(
     /**
      * Highlight the mini-editor in the tool window whose name corresponds with the name of the test provided
      *
-     * @param name name of the test whose editor should be highlighted
+     * @param id id of the test whose editor should be highlighted
      */
-    private fun highlightTestCase(name: String) {
-        val myPanel = generatedTestsTabData.testCaseNameToPanel[name] ?: return
+    private fun highlightTestCase(id: Int) {
+        val myPanel = generatedTestsTabData.testCaseIdToPanel[id] ?: return
         openToolWindowTab()
         scrollToPanel(myPanel)
 
-        val editorTextField = generatedTestsTabData.testCaseNameToEditorTextField[name] ?: return
+        val editorTextField = generatedTestsTabData.testCaseIdToEditorTextField[id] ?: return
         val settingsProjectState = project.service<PluginSettingsService>().state
         val highlightColor =
             JBColor(
@@ -229,10 +230,10 @@ class CoverageRenderer(
 
     /**
      * Highlight a range of editors
-     * @param names list of test names to pass to highlight function
+     * @param ids list of test ids to pass to highlight function
      */
-    private fun highlightCoveredMutants(names: List<String>) {
-        names.forEach {
+    private fun highlightCoveredMutants(ids: List<Int>) {
+        ids.forEach {
             highlightTestCase(it)
         }
     }

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageVisualisationTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageVisualisationTabBuilder.kt
@@ -25,6 +25,7 @@ import java.awt.Dimension
 import javax.swing.JScrollPane
 import javax.swing.table.AbstractTableModel
 import kotlin.math.roundToInt
+import org.jetbrains.research.testspark.core.data.TestCase
 
 /**
  * This class is responsible for building and managing the "Coverage" tab in TestSpark.
@@ -129,16 +130,16 @@ class CoverageVisualisationTabBuilder(
             textAttribute.backgroundColor = colorForLines
 
             // map of mutant operations -> List of names of tests which cover the mutant
-            val mapMutantsToTests = HashMap<String, MutableList<String>>()
+            val mapMutantsToTests = HashMap<String, MutableList<Int>>()
 
             testReport.testCaseList.values.forEach { compactTestCase ->
                 // Since we are in the IntelliJ plugin's visualizer, all test cases should be an instance of IJTestCase
                 if (compactTestCase is IJTestCase) {
                     val mutantsCovered = compactTestCase.coveredMutants
-                    val testName = compactTestCase.testName
+                    val testId = compactTestCase.id
                     mutantsCovered.forEach {
                         val testCasesCoveringMutant = mapMutantsToTests.getOrPut(it.replacement) { ArrayList() }
-                        testCasesCoveringMutant.add(testName)
+                        testCasesCoveringMutant.add(testId)
                     }
                 } else {
                     throw IllegalStateException(
@@ -187,10 +188,10 @@ class CoverageVisualisationTabBuilder(
         testReport: Report,
         selectedTests: HashSet<Int>,
         lineNumber: Int,
-    ): List<String> =
+    ): List<TestCase> =
         testReport.testCaseList
             .filter { x -> lineNumber in x.value.coveredLines && x.value.id in selectedTests }
-            .map { x -> x.value.testName }
+            .map { x -> x.value }
 
     private fun getUncoveredMutants(
         testReport: Report,

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageVisualisationTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/coverage/CoverageVisualisationTabBuilder.kt
@@ -16,6 +16,7 @@ import org.evosuite.result.MutationInfo
 import org.jetbrains.research.testspark.bundles.plugin.PluginLabelsBundle
 import org.jetbrains.research.testspark.bundles.plugin.PluginSettingsBundle
 import org.jetbrains.research.testspark.core.data.Report
+import org.jetbrains.research.testspark.core.data.TestCase
 import org.jetbrains.research.testspark.data.IJReport
 import org.jetbrains.research.testspark.data.IJTestCase
 import org.jetbrains.research.testspark.display.generatedTests.GeneratedTestsTabData
@@ -25,7 +26,6 @@ import java.awt.Dimension
 import javax.swing.JScrollPane
 import javax.swing.table.AbstractTableModel
 import kotlin.math.roundToInt
-import org.jetbrains.research.testspark.core.data.TestCase
 
 /**
  * This class is responsible for building and managing the "Coverage" tab in TestSpark.

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GenerateTestsTabHelper.kt
@@ -4,28 +4,28 @@ object GenerateTestsTabHelper {
     /**
      * A helper method to remove a test case from the cache and from the UI.
      *
-     * @param testCaseName the name of the test
+     * @param testCaseId the id of the test
      */
     fun removeTestCase(
-        testCaseName: String,
+        testCaseId: Int,
         generatedTestsTabData: GeneratedTestsTabData,
     ) {
         // Update the number of selected test cases if necessary
-        if (generatedTestsTabData.testCaseNameToSelectedCheckbox[testCaseName]!!.isSelected) {
+        if (generatedTestsTabData.testCaseIdToSelectedCheckbox[testCaseId]!!.isSelected) {
             generatedTestsTabData.testsSelected--
         }
 
         // Remove the test panel from the UI
-        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseNameToPanel[testCaseName])
+        generatedTestsTabData.allTestCasePanel.remove(generatedTestsTabData.testCaseIdToPanel[testCaseId])
 
         // Remove the test panel
-        generatedTestsTabData.testCaseNameToPanel.remove(testCaseName)
+        generatedTestsTabData.testCaseIdToPanel.remove(testCaseId)
 
         // Remove the selected checkbox
-        generatedTestsTabData.testCaseNameToSelectedCheckbox.remove(testCaseName)
+        generatedTestsTabData.testCaseIdToSelectedCheckbox.remove(testCaseId)
 
         // Remove the editorTextField
-        generatedTestsTabData.testCaseNameToEditorTextField.remove(testCaseName)
+        generatedTestsTabData.testCaseIdToEditorTextField.remove(testCaseId)
     }
 
     /**

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabBuilder.kt
@@ -62,7 +62,7 @@ class GeneratedTestsTabBuilder(
         generatedTestsTabData.allTestCasePanel.removeAll()
         generatedTestsTabData.allTestCasePanel.layout =
             BoxLayout(generatedTestsTabData.allTestCasePanel, BoxLayout.Y_AXIS)
-        generatedTestsTabData.testCaseNameToPanel.clear()
+        generatedTestsTabData.testCaseIdToPanel.clear()
 
         generatedTestsTabData.contentManager = contentManager
 
@@ -180,12 +180,12 @@ class GeneratedTestsTabBuilder(
             generatedTestsTabData.allTestCasePanel.add(testCasePanel)
             addSeparator()
 
-            generatedTestsTabData.testCaseNameToPanel[testCase.testName] = testCasePanel
-            generatedTestsTabData.testCaseNameToSelectedCheckbox[testCase.testName] = checkbox
-            generatedTestsTabData.testCaseNameToEditorTextField[testCase.testName] =
+            generatedTestsTabData.testCaseIdToPanel[testCase.id] = testCasePanel
+            generatedTestsTabData.testCaseIdToSelectedCheckbox[testCase.id] = checkbox
+            generatedTestsTabData.testCaseIdToEditorTextField[testCase.id] =
                 testCasePanelBuilder.getEditorTextField()
         }
-        generatedTestsTabData.testsSelected = generatedTestsTabData.testCaseNameToPanel.size
+        generatedTestsTabData.testsSelected = generatedTestsTabData.testCaseIdToPanel.size
         generatedTestsTabData.testCasePanelFactories.addAll(testCasePanelFactories)
         generatedTestsTabData.topButtonsPanelBuilder.update(generatedTestsTabData)
     }
@@ -205,13 +205,13 @@ class GeneratedTestsTabBuilder(
     fun applyTests(): Boolean {
         // Filter the selected test cases
         val selectedTestCasePanels =
-            generatedTestsTabData.testCaseNameToPanel.filter { (it.value.getComponent(0) as JCheckBox).isSelected }
+            generatedTestsTabData.testCaseIdToPanel.filter { (it.value.getComponent(0) as JCheckBox).isSelected }
         val selectedTestCases = selectedTestCasePanels.map { it.key }
 
         // Get the test case components (source code of the tests)
         val testCaseComponents =
             selectedTestCases
-                .map { generatedTestsTabData.testCaseNameToEditorTextField[it]!! }
+                .map { generatedTestsTabData.testCaseIdToEditorTextField[it]!! }
                 .map { it.document.text }
 
         val applyingResult = displayUtils!!.applyTests(project, uiContext, testCaseComponents)
@@ -263,7 +263,7 @@ class GeneratedTestsTabBuilder(
      * Clears all the generated test cases from the UI and the internal cache.
      */
     fun clear() {
-        generatedTestsTabData.testCaseNameToPanel
+        generatedTestsTabData.testCaseIdToPanel
             .toMap()
             .forEach { GenerateTestsTabHelper.removeTestCase(it.key, generatedTestsTabData) }
         generatedTestsTabData.testCasePanelFactories.clear()

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/GeneratedTestsTabData.kt
@@ -14,9 +14,9 @@ import javax.swing.JPanel
 class GeneratedTestsTabData(
     val indicatorController: IndicatorController,
 ) {
-    val testCaseNameToPanel: HashMap<String, JPanel> = HashMap()
-    val testCaseNameToSelectedCheckbox: HashMap<String, JCheckBox> = HashMap()
-    val testCaseNameToEditorTextField: HashMap<String, EditorTextField> = HashMap()
+    val testCaseIdToPanel: HashMap<Int, JPanel> = HashMap()
+    val testCaseIdToSelectedCheckbox: HashMap<Int, JCheckBox> = HashMap()
+    val testCaseIdToEditorTextField: HashMap<Int, EditorTextField> = HashMap()
     var testsSelected: Int = 0
     val unselectedTestCases: HashMap<Int, TestCase> = HashMap()
     val testCasePanelFactories: ArrayList<TestCasePanelBuilder> = arrayListOf()

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -225,7 +225,7 @@ class TestCasePanelBuilder(
             val clipboard: Clipboard = Toolkit.getDefaultToolkit().systemClipboard
             clipboard.setContents(
                 StringSelection(
-                    generatedTestsTabData.testCaseNameToEditorTextField[testCase.testName]!!.document.text,
+                    generatedTestsTabData.testCaseIdToEditorTextField[testCase.id]!!.document.text,
                 ),
                 null,
             )
@@ -756,7 +756,7 @@ class TestCasePanelBuilder(
      */
     private fun remove() {
         // Remove the test case from the cache
-        GenerateTestsTabHelper.removeTestCase(testCase.testName, generatedTestsTabData)
+        GenerateTestsTabHelper.removeTestCase(testCase.id, generatedTestsTabData)
 
         runTestButton.isEnabled = false
         isRemoved = true

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TopButtonsPanelBuilder.kt
@@ -55,13 +55,13 @@ class TopButtonsPanelBuilder {
             String.format(
                 testsSelectedText,
                 generatedTestsTabData.testsSelected,
-                generatedTestsTabData.testCaseNameToPanel.size,
+                generatedTestsTabData.testCaseIdToPanel.size,
             )
         testsPassedLabel.text =
             String.format(
                 testsPassedText,
                 passedTestsCount,
-                generatedTestsTabData.testCaseNameToPanel.size,
+                generatedTestsTabData.testCaseIdToPanel.size,
             )
         runAllButton.isEnabled = false
         for (testCasePanelFactory in generatedTestsTabData.testCasePanelFactories) {
@@ -81,11 +81,11 @@ class TopButtonsPanelBuilder {
         selected: Boolean,
         generatedTestsTabData: GeneratedTestsTabData,
     ) {
-        generatedTestsTabData.testCaseNameToPanel.forEach { (_, jPanel) ->
+        generatedTestsTabData.testCaseIdToPanel.forEach { (_, jPanel) ->
             val checkBox = jPanel.getComponent(0) as JCheckBox
             checkBox.isSelected = selected
         }
-        generatedTestsTabData.testsSelected = if (selected) generatedTestsTabData.testCaseNameToPanel.size else 0
+        generatedTestsTabData.testsSelected = if (selected) generatedTestsTabData.testCaseIdToPanel.size else 0
     }
 
     /**


### PR DESCRIPTION
# Description of changes made
The test case data is stored in a mape, where the keys are method names. But since users can change these names, this leads to a lot of problems. For example, if you change the name of a method and delete it, you will get an error. And you can't have 2 methods with the same name, because the whole mapping breaks. 
I changed the storage by name to storage by id, which is unique and immutable. 

# Other notes
Closes #368

- [x] I have checked that I am merging into correct branch
