### PR TITLE
[Build] pin verifyPlugin to 1.383

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,7 +138,7 @@ dependencies {
         // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
         bundledPlugins(providers.gradleProperty("platformPlugins").map { it.split(',') })
 
-        pluginVerifier()
+        pluginVerifier("1.383")
         zipSigner()
         instrumentationTools()
 


### PR DESCRIPTION
# Description of changes made

When using the latest version (1.384), there is a spike in ram usage at some point. When the task "verifyPlugin" is executed inside a GH Actions, the run fails with an Out Of Memory issue

# Why is merge request needed

The build GitHub Actions jobs failed with version 1.384

# Other notes

*Please write if you have anything to add*

# What is missing?
*Please mention if anything is missing for this merge request, e.g you have decided to move something to the next merge request*

- [x] I have checked that I am merging into correct branch
