### PR TITLE
[#470] Replace deprecated APIs

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/generatedTests/TestCasePanelBuilder.kt
@@ -15,6 +15,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.util.Disposer
 import com.intellij.psi.JavaRecursiveElementVisitor
 import com.intellij.psi.PsiClassInitializer
 import com.intellij.psi.PsiDocumentManager
@@ -54,6 +55,7 @@ import org.jetbrains.research.testspark.display.utils.ModifiedLinesGetter
 import org.jetbrains.research.testspark.display.utils.ReportUpdater
 import org.jetbrains.research.testspark.helpers.LLMHelper
 import org.jetbrains.research.testspark.services.LLMSettingsService
+import org.jetbrains.research.testspark.services.TestSparkPluginDisposable
 import org.jetbrains.research.testspark.settings.llm.LLMSettingsState
 import org.jetbrains.research.testspark.testmanager.TestAnalyzerFactory
 import org.jetbrains.research.testspark.tools.GenerationTool
@@ -266,13 +268,16 @@ class TestCasePanelBuilder(
 
         addLanguageTextFieldListener(languageTextField)
 
+        val disposable = Disposer.newDisposable("MiddlePanelDisposable")
         PsiManager.getInstance(project).addPsiTreeChangeListener(
             object : PsiTreeChangeAdapter() {
                 override fun childAdded(event: PsiTreeChangeEvent) {
                     languageTextField.editor?.foldHelperCode()
                 }
             },
+            disposable,
         )
+        Disposer.register(TestSparkPluginDisposable.getInstance(), disposable)
         return panel
     }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/services/TestSparkPluginDisposable.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/services/TestSparkPluginDisposable.kt
@@ -1,0 +1,23 @@
+package org.jetbrains.research.testspark.services
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.project.Project
+
+/** A disposable to be used as a parent for the TestSpark plugin, instead of the project or application. */
+@Service(Service.Level.APP, Service.Level.PROJECT)
+class TestSparkPluginDisposable : Disposable {
+    companion object {
+        fun getInstance(): Disposable = ApplicationManager.getApplication().getService(TestSparkPluginDisposable::class.java)
+
+        fun getInstance(project: Project): Disposable = project.getService(TestSparkPluginDisposable::class.java)
+    }
+
+    override fun dispose() {
+        // Intentionally left empty, adopted from
+        // https://github.com/JetBrains/intellij-community/blob/idea/243.26053.27/python/openapi/src/com/jetbrains/python/PythonPluginDisposable.java
+        // which is mentioned in the documentation
+        // (https://plugins.jetbrains.com/docs/intellij/disposers.html?from=IncorrectParentDisposable#choosing-a-disposable-parent)
+    }
+}

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/kex/generation/KexProcessManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/kex/generation/KexProcessManager.kt
@@ -31,7 +31,7 @@ import org.jetbrains.research.testspark.tools.llm.generation.StandardRequestMana
 import org.jetbrains.research.testspark.tools.template.generation.ProcessManager
 import java.io.File
 import java.io.IOException
-import java.net.URL
+import java.net.URI
 import java.nio.charset.Charset
 import java.util.zip.ZipInputStream
 import kotlin.io.path.Path
@@ -242,7 +242,7 @@ class KexProcessManager(
         log.info("Kex executable and helper files not found, downloading Kex")
         val stream =
             try {
-                URL(kexUrl).openStream()
+                URI(kexUrl).toURL().openStream()
             } catch (e: Exception) {
                 log.error("Error fetching latest kex custom release - $e")
                 return false


### PR DESCRIPTION
Replaces deprecated APIs as warned by the verifyer plugin.

`URL(String)` shall be replaced by `URI(String).toURL` according to the [Javadocs of the JDK](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String)) (`URL(String)` is deprecated from Java 20).

`addPsiTreeChangeListener(PsiTreeChangeListener)` shall be replaced by `addPsiTreeChangeListener(PsiTreeChangeListener, Disposable)`, which required to add a plugin-level `Disposable`; the relevant links to the documentation are comments in the code.

Fixes #470 