### PR TITLE
[#160] Support of ExtendWith annotation

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/TestGenerationData.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/data/TestGenerationData.kt
@@ -14,7 +14,7 @@ data class TestGenerationData(
     // Code required of imports and package for generated tests
     var importsCode: MutableSet<String> = mutableSetOf(),
     var packageName: String = "",
-    var runWith: String = "",
+    var annotation: String = "",
     // Modifications to this code in the tool-window editor are forgotten when apply to test suite
     var otherInfo: String = "",
     // changing parameters with a large prompt
@@ -30,7 +30,7 @@ data class TestGenerationData(
         fileUrl = ""
         importsCode = mutableSetOf()
         packageName = ""
-        runWith = ""
+        annotation = ""
         otherInfo = ""
         polyDepthReducing = 0
         inputParamsDepthReducing = 0

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/data/TestSuiteGeneratedByLLM.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/data/TestSuiteGeneratedByLLM.kt
@@ -10,7 +10,7 @@ package org.jetbrains.research.testspark.core.test.data
 data class TestSuiteGeneratedByLLM(
     var imports: MutableSet<String> = mutableSetOf(),
     var packageName: String = "",
-    var runWith: String = "",
+    var annotation: String = "",
     var otherInfo: String = "",
     var testCases: MutableList<TestCaseGeneratedByLLM> = mutableListOf(),
 ) {

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaJUnitTestSuiteParser.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaJUnitTestSuiteParser.kt
@@ -22,7 +22,6 @@ class JavaJUnitTestSuiteParser(
 
         return JUnitTestSuiteParserStrategy.parseJUnitTestSuite(
             rawText,
-            junitVersion,
             javaImportPattern,
             packageName,
             testNamePattern = "void",

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinJUnitTestSuiteParser.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinJUnitTestSuiteParser.kt
@@ -22,7 +22,6 @@ class KotlinJUnitTestSuiteParser(
 
         return JUnitTestSuiteParserStrategy.parseJUnitTestSuite(
             rawText,
-            junitVersion,
             kotlinImportPattern,
             packageName,
             testNamePattern = "fun",

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/strategies/JUnitTestSuiteParserStrategy.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/strategies/JUnitTestSuiteParserStrategy.kt
@@ -21,7 +21,6 @@ class JUnitTestSuiteParserStrategy {
     companion object {
         fun parseJUnitTestSuite(
             rawText: String,
-            junitVersion: JUnitVersion,
             importPattern: Regex,
             packageName: String,
             testNamePattern: String,

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/strategies/JUnitTestSuiteParserStrategy.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/strategies/JUnitTestSuiteParserStrategy.kt
@@ -41,8 +41,9 @@ class JUnitTestSuiteParserStrategy {
                         .map { it.groupValues[0] }
                         .toMutableSet()
 
-                // save RunWith
-                val runWith: String = junitVersion.runWithAnnotationMeta.extract(rawCode) ?: ""
+                // save ExtendWith or RunWith annotation if present
+                val runWithAnnotation: String = JUnitVersion.JUnit4.runWithAnnotationMeta.extract(rawCode) ?: ""
+                val annotation = JUnitVersion.JUnit5.runWithAnnotationMeta.extract(rawCode) ?: runWithAnnotation
 
                 val testSet: MutableList<String> = rawCode.split("@Test").toMutableList()
 
@@ -82,7 +83,7 @@ class JUnitTestSuiteParserStrategy {
                     TestSuiteGeneratedByLLM(
                         imports = imports,
                         packageName = packageName,
-                        runWith = runWith,
+                        annotation = annotation,
                         otherInfo = otherInfo,
                         testCases = testCases,
                     )

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/java/JavaDisplayUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/java/JavaDisplayUtils.kt
@@ -22,6 +22,7 @@ import org.jetbrains.research.testspark.display.utils.ErrorMessageManager
 import org.jetbrains.research.testspark.display.utils.template.DisplayUtils
 import org.jetbrains.research.testspark.java.JavaPsiClassWrapper
 import org.jetbrains.research.testspark.langwrappers.PsiClassWrapper
+import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.testmanager.java.JavaTestAnalyzer
 import org.jetbrains.research.testspark.testmanager.java.JavaTestGenerator
 import java.io.File
@@ -41,22 +42,22 @@ class JavaDisplayUtils : DisplayUtils {
         WriteCommandAction.runWriteCommandAction(project) {
             descriptor.withFileFilter { file ->
                 file.isDirectory ||
-                    (
-                        file.extension?.lowercase(Locale.getDefault()) == "java" &&
-                            (
-                                PsiManager.getInstance(project).findFile(file!!) as PsiJavaFile
-                            ).classes
-                                .stream()
-                                .map { it.name }
-                                .toArray()
-                                .contains(
-                                    (
-                                        PsiManager
-                                            .getInstance(project)
-                                            .findFile(file) as PsiJavaFile
-                                    ).name.removeSuffix(".java"),
+                        (
+                                file.extension?.lowercase(Locale.getDefault()) == "java" &&
+                                        (
+                                                PsiManager.getInstance(project).findFile(file!!) as PsiJavaFile
+                                                ).classes
+                                            .stream()
+                                            .map { it.name }
+                                            .toArray()
+                                            .contains(
+                                                (
+                                                        PsiManager
+                                                            .getInstance(project)
+                                                            .findFile(file) as PsiJavaFile
+                                                        ).name.removeSuffix(".java"),
+                                            )
                                 )
-                    )
             }
         }
 
@@ -142,7 +143,8 @@ class JavaDisplayUtils : DisplayUtils {
                 psiClass = PsiElementFactory.getInstance(project).createClass(className.split(".")[0])
 
                 if (uiContext!!.testGenerationOutput.annotation.isNotEmpty()) {
-                    psiClass!!.modifierList!!.addAnnotation("RunWith(${uiContext.testGenerationOutput.annotation})")
+                    val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
+                    psiClass!!.modifierList!!.addAnnotation("${junitVersion.runWithAnnotationMeta.annotationName}(${uiContext.testGenerationOutput.annotation})")
                 }
 
                 psiJavaFile!!.add(psiClass!!)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/java/JavaDisplayUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/java/JavaDisplayUtils.kt
@@ -141,8 +141,8 @@ class JavaDisplayUtils : DisplayUtils {
                 psiJavaFile = (PsiManager.getInstance(project).findFile(virtualFile!!) as PsiJavaFile)
                 psiClass = PsiElementFactory.getInstance(project).createClass(className.split(".")[0])
 
-                if (uiContext!!.testGenerationOutput.runWith.isNotEmpty()) {
-                    psiClass!!.modifierList!!.addAnnotation("RunWith(${uiContext.testGenerationOutput.runWith})")
+                if (uiContext!!.testGenerationOutput.annotation.isNotEmpty()) {
+                    psiClass!!.modifierList!!.addAnnotation("RunWith(${uiContext.testGenerationOutput.annotation})")
                 }
 
                 psiJavaFile!!.add(psiClass!!)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/java/JavaDisplayUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/java/JavaDisplayUtils.kt
@@ -42,22 +42,22 @@ class JavaDisplayUtils : DisplayUtils {
         WriteCommandAction.runWriteCommandAction(project) {
             descriptor.withFileFilter { file ->
                 file.isDirectory ||
-                        (
-                                file.extension?.lowercase(Locale.getDefault()) == "java" &&
-                                        (
-                                                PsiManager.getInstance(project).findFile(file!!) as PsiJavaFile
-                                                ).classes
-                                            .stream()
-                                            .map { it.name }
-                                            .toArray()
-                                            .contains(
-                                                (
-                                                        PsiManager
-                                                            .getInstance(project)
-                                                            .findFile(file) as PsiJavaFile
-                                                        ).name.removeSuffix(".java"),
-                                            )
+                    (
+                        file.extension?.lowercase(Locale.getDefault()) == "java" &&
+                            (
+                                PsiManager.getInstance(project).findFile(file!!) as PsiJavaFile
+                            ).classes
+                                .stream()
+                                .map { it.name }
+                                .toArray()
+                                .contains(
+                                    (
+                                        PsiManager
+                                            .getInstance(project)
+                                            .findFile(file) as PsiJavaFile
+                                    ).name.removeSuffix(".java"),
                                 )
+                    )
             }
         }
 
@@ -144,7 +144,9 @@ class JavaDisplayUtils : DisplayUtils {
 
                 if (uiContext!!.testGenerationOutput.annotation.isNotEmpty()) {
                     val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
-                    psiClass!!.modifierList!!.addAnnotation("${junitVersion.runWithAnnotationMeta.annotationName}(${uiContext.testGenerationOutput.annotation})")
+                    psiClass!!.modifierList!!.addAnnotation(
+                        "${junitVersion.runWithAnnotationMeta.annotationName}(${uiContext.testGenerationOutput.annotation})",
+                    )
                 }
 
                 psiJavaFile!!.add(psiClass!!)

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/kotlin/KotlinDisplayUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/kotlin/KotlinDisplayUtils.kt
@@ -24,6 +24,7 @@ import org.jetbrains.research.testspark.display.utils.ErrorMessageManager
 import org.jetbrains.research.testspark.display.utils.template.DisplayUtils
 import org.jetbrains.research.testspark.kotlin.KotlinPsiClassWrapper
 import org.jetbrains.research.testspark.langwrappers.PsiClassWrapper
+import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.testmanager.kotlin.KotlinTestAnalyzer
 import org.jetbrains.research.testspark.testmanager.kotlin.KotlinTestGenerator
 import java.io.File
@@ -42,22 +43,22 @@ class KotlinDisplayUtils : DisplayUtils {
         WriteCommandAction.runWriteCommandAction(project) {
             descriptor.withFileFilter { file ->
                 file.isDirectory ||
-                    (
-                        file.extension?.lowercase(Locale.getDefault()) == "kotlin" &&
-                            (
-                                PsiManager.getInstance(project).findFile(file!!) as KtFile
-                            ).classes
-                                .stream()
-                                .map { it.name }
-                                .toArray()
-                                .contains(
-                                    (
-                                        PsiManager
-                                            .getInstance(project)
-                                            .findFile(file) as PsiJavaFile
-                                    ).name.removeSuffix(".kt"),
+                        (
+                                file.extension?.lowercase(Locale.getDefault()) == "kotlin" &&
+                                        (
+                                                PsiManager.getInstance(project).findFile(file!!) as KtFile
+                                                ).classes
+                                            .stream()
+                                            .map { it.name }
+                                            .toArray()
+                                            .contains(
+                                                (
+                                                        PsiManager
+                                                            .getInstance(project)
+                                                            .findFile(file) as PsiJavaFile
+                                                        ).name.removeSuffix(".kt"),
+                                            )
                                 )
-                    )
             }
         }
 
@@ -145,8 +146,9 @@ class KotlinDisplayUtils : DisplayUtils {
                 ktClass = ktPsiFactory.createClass("class ${className.split(".")[0]} {}")
 
                 if (uiContext!!.testGenerationOutput.annotation.isNotEmpty()) {
+                    val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
                     val annotationEntry =
-                        ktPsiFactory.createAnnotationEntry("@RunWith(${uiContext.testGenerationOutput.annotation})")
+                        ktPsiFactory.createAnnotationEntry("@${junitVersion.runWithAnnotationMeta.annotationName}(${uiContext.testGenerationOutput.annotation})")
                     ktClass!!.addBefore(annotationEntry, ktClass!!.body)
                 }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/kotlin/KotlinDisplayUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/kotlin/KotlinDisplayUtils.kt
@@ -144,9 +144,9 @@ class KotlinDisplayUtils : DisplayUtils {
                 val ktPsiFactory = KtPsiFactory(project)
                 ktClass = ktPsiFactory.createClass("class ${className.split(".")[0]} {}")
 
-                if (uiContext!!.testGenerationOutput.runWith.isNotEmpty()) {
+                if (uiContext!!.testGenerationOutput.annotation.isNotEmpty()) {
                     val annotationEntry =
-                        ktPsiFactory.createAnnotationEntry("@RunWith(${uiContext.testGenerationOutput.runWith})")
+                        ktPsiFactory.createAnnotationEntry("@RunWith(${uiContext.testGenerationOutput.annotation})")
                     ktClass!!.addBefore(annotationEntry, ktClass!!.body)
                 }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/display/utils/kotlin/KotlinDisplayUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/display/utils/kotlin/KotlinDisplayUtils.kt
@@ -43,22 +43,22 @@ class KotlinDisplayUtils : DisplayUtils {
         WriteCommandAction.runWriteCommandAction(project) {
             descriptor.withFileFilter { file ->
                 file.isDirectory ||
-                        (
-                                file.extension?.lowercase(Locale.getDefault()) == "kotlin" &&
-                                        (
-                                                PsiManager.getInstance(project).findFile(file!!) as KtFile
-                                                ).classes
-                                            .stream()
-                                            .map { it.name }
-                                            .toArray()
-                                            .contains(
-                                                (
-                                                        PsiManager
-                                                            .getInstance(project)
-                                                            .findFile(file) as PsiJavaFile
-                                                        ).name.removeSuffix(".kt"),
-                                            )
+                    (
+                        file.extension?.lowercase(Locale.getDefault()) == "kotlin" &&
+                            (
+                                PsiManager.getInstance(project).findFile(file!!) as KtFile
+                            ).classes
+                                .stream()
+                                .map { it.name }
+                                .toArray()
+                                .contains(
+                                    (
+                                        PsiManager
+                                            .getInstance(project)
+                                            .findFile(file) as PsiJavaFile
+                                    ).name.removeSuffix(".kt"),
                                 )
+                    )
             }
         }
 
@@ -148,7 +148,9 @@ class KotlinDisplayUtils : DisplayUtils {
                 if (uiContext!!.testGenerationOutput.annotation.isNotEmpty()) {
                     val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
                     val annotationEntry =
-                        ktPsiFactory.createAnnotationEntry("@${junitVersion.runWithAnnotationMeta.annotationName}(${uiContext.testGenerationOutput.annotation})")
+                        ktPsiFactory.createAnnotationEntry(
+                            "@${junitVersion.runWithAnnotationMeta.annotationName}(${uiContext.testGenerationOutput.annotation})",
+                        )
                     ktClass!!.addBefore(annotationEntry, ktClass!!.body)
                 }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/testmanager/java/JavaTestGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/testmanager/java/JavaTestGenerator.kt
@@ -78,7 +78,7 @@ object JavaTestGenerator : TestGenerator {
         packageString: String,
         annotation: String,
         otherInfo: String,
-        project: Project
+        project: Project,
     ): String {
         var testText = ""
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/testmanager/java/JavaTestGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/testmanager/java/JavaTestGenerator.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.jetbrains.research.testspark.core.data.TestGenerationData
+import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.testmanager.template.TestGenerator
 import java.io.File
 
@@ -25,7 +26,7 @@ object JavaTestGenerator : TestGenerator {
         otherInfo: String,
         testGenerationData: TestGenerationData,
     ): String {
-        var testFullText = printUpperPart(className, imports, packageString, runWith, otherInfo)
+        var testFullText = printUpperPart(className, imports, packageString, runWith, otherInfo, project)
 
         // Add each test (exclude expected exception)
         testFullText += body
@@ -77,6 +78,7 @@ object JavaTestGenerator : TestGenerator {
         packageString: String,
         runWith: String,
         otherInfo: String,
+        project: Project
     ): String {
         var testText = ""
 
@@ -94,7 +96,8 @@ object JavaTestGenerator : TestGenerator {
 
         // add runWith if exists
         if (runWith.isNotBlank()) {
-            testText += "@RunWith($runWith)\n"
+            val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
+            testText += "@${junitVersion.runWithAnnotationMeta.annotationName}($runWith)\n"
         }
         // open the test class
         testText += "public class $className {\n\n"

--- a/src/main/kotlin/org/jetbrains/research/testspark/testmanager/java/JavaTestGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/testmanager/java/JavaTestGenerator.kt
@@ -22,11 +22,11 @@ object JavaTestGenerator : TestGenerator {
         body: String,
         imports: Set<String>,
         packageString: String,
-        runWith: String,
+        annotation: String,
         otherInfo: String,
         testGenerationData: TestGenerationData,
     ): String {
-        var testFullText = printUpperPart(className, imports, packageString, runWith, otherInfo, project)
+        var testFullText = printUpperPart(className, imports, packageString, annotation, otherInfo, project)
 
         // Add each test (exclude expected exception)
         testFullText += body
@@ -76,7 +76,7 @@ object JavaTestGenerator : TestGenerator {
         className: String,
         imports: Set<String>,
         packageString: String,
-        runWith: String,
+        annotation: String,
         otherInfo: String,
         project: Project
     ): String {
@@ -94,10 +94,10 @@ object JavaTestGenerator : TestGenerator {
 
         testText += "\n"
 
-        // add runWith if exists
-        if (runWith.isNotBlank()) {
+        // add RunWith or ExtendWith annotation if exists
+        if (annotation.isNotBlank()) {
             val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
-            testText += "@${junitVersion.runWithAnnotationMeta.annotationName}($runWith)\n"
+            testText += "@${junitVersion.runWithAnnotationMeta.annotationName}($annotation)\n"
         }
         // open the test class
         testText += "public class $className {\n\n"

--- a/src/main/kotlin/org/jetbrains/research/testspark/testmanager/kotlin/KotlinTestGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/testmanager/kotlin/KotlinTestGenerator.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.codeStyle.CodeStyleManager
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.research.testspark.core.data.TestGenerationData
+import org.jetbrains.research.testspark.services.LLMSettingsService
 import org.jetbrains.research.testspark.testmanager.template.TestGenerator
 import java.io.File
 
@@ -28,7 +29,7 @@ object KotlinTestGenerator : TestGenerator {
         log.debug("[KotlinClassBuilderHelper] Generate code for $className")
 
         var testFullText =
-            printUpperPart(className, imports, packageString, runWith, otherInfo)
+            printUpperPart(className, imports, packageString, runWith, otherInfo, project)
 
         // Add each test (exclude expected exception)
         testFullText += body
@@ -73,6 +74,7 @@ object KotlinTestGenerator : TestGenerator {
         packageString: String,
         runWith: String,
         otherInfo: String,
+        project: Project,
     ): String {
         var testText = ""
 
@@ -90,7 +92,8 @@ object KotlinTestGenerator : TestGenerator {
 
         // Add runWith if exists
         if (runWith.isNotBlank()) {
-            testText += "@RunWith($runWith::class)\n"
+            val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
+            testText += "@${junitVersion.runWithAnnotationMeta.annotationName}($runWith::class)\n"
         }
 
         // Open the test class

--- a/src/main/kotlin/org/jetbrains/research/testspark/testmanager/kotlin/KotlinTestGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/testmanager/kotlin/KotlinTestGenerator.kt
@@ -22,14 +22,14 @@ object KotlinTestGenerator : TestGenerator {
         body: String,
         imports: Set<String>,
         packageString: String,
-        runWith: String,
+        annotation: String,
         otherInfo: String,
         testGenerationData: TestGenerationData,
     ): String {
         log.debug("[KotlinClassBuilderHelper] Generate code for $className")
 
         var testFullText =
-            printUpperPart(className, imports, packageString, runWith, otherInfo, project)
+            printUpperPart(className, imports, packageString, annotation, otherInfo, project)
 
         // Add each test (exclude expected exception)
         testFullText += body
@@ -72,7 +72,7 @@ object KotlinTestGenerator : TestGenerator {
         className: String,
         imports: Set<String>,
         packageString: String,
-        runWith: String,
+        annotation: String,
         otherInfo: String,
         project: Project,
     ): String {
@@ -90,10 +90,10 @@ object KotlinTestGenerator : TestGenerator {
 
         testText += "\n"
 
-        // Add runWith if exists
-        if (runWith.isNotBlank()) {
+        // Add ExtendWith or RunWith annotation if exists
+        if (annotation.isNotBlank()) {
             val junitVersion = project.getService(LLMSettingsService::class.java).state.junitVersion
-            testText += "@${junitVersion.runWithAnnotationMeta.annotationName}($runWith::class)\n"
+            testText += "@${junitVersion.runWithAnnotationMeta.annotationName}($annotation::class)\n"
         }
 
         // Open the test class

--- a/src/main/kotlin/org/jetbrains/research/testspark/testmanager/template/TestGenerator.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/testmanager/template/TestGenerator.kt
@@ -15,7 +15,7 @@ interface TestGenerator {
      * @param body the body of the test class
      * @param imports the set of imports needed in the test class
      * @param packageString the package declaration of the test class
-     * @param runWith the runWith annotation for the test class
+     * @param annotation the RunWith or ExtendWith annotation for the test class
      * @param otherInfo any other additional information for the test class
      * @param testGenerationData the data used for test generation
      * @return the generated code as a string
@@ -26,7 +26,7 @@ interface TestGenerator {
         body: String,
         imports: Set<String>,
         packageString: String,
-        runWith: String,
+        annotation: String,
         otherInfo: String,
         testGenerationData: TestGenerationData,
     ): String

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/ToolUtils.kt
@@ -59,7 +59,7 @@ object ToolUtils {
                     code,
                     generatedTestData.importsCode,
                     generatedTestData.packageName,
-                    generatedTestData.runWith,
+                    generatedTestData.annotation,
                     generatedTestData.otherInfo,
                     generatedTestData,
                 )

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/JUnitTestsAssembler.kt
@@ -52,11 +52,11 @@ class JUnitTestsAssembler(
         val testSuite = testSuiteParser.parseTestSuite(super.getContent())
 
         // save RunWith
-        if (testSuite?.runWith?.isNotBlank() == true) {
-            generationData.runWith = testSuite.runWith
+        if (testSuite?.annotation?.isNotBlank() == true) {
+            generationData.annotation = testSuite.annotation
             generationData.importsCode.add(junitVersion.runWithAnnotationMeta.import)
         } else {
-            generationData.runWith = ""
+            generationData.annotation = ""
             generationData.importsCode.remove(junitVersion.runWithAnnotationMeta.import)
         }
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/test/JUnitTestSuitePresenter.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/test/JUnitTestSuitePresenter.kt
@@ -42,7 +42,7 @@ class JUnitTestSuitePresenter(
                 testBody,
                 imports,
                 packageName,
-                runWith,
+                annotation,
                 otherInfo,
                 generatedTestsData,
             )
@@ -65,7 +65,7 @@ class JUnitTestSuitePresenter(
                 testCases[testCaseIndex].toStringWithoutExpectedException() + "\n",
                 imports,
                 packageName,
-                runWith,
+                annotation,
                 otherInfo,
                 generatedTestsData,
             )
@@ -89,7 +89,7 @@ class JUnitTestSuitePresenter(
                 testBody,
                 imports,
                 packageName,
-                runWith,
+                annotation,
                 otherInfo,
                 generatedTestsData,
             )


### PR DESCRIPTION
# Description of changes made
Previously, both `ExtendWith` and `RunWith` annotations were replaced with `RunWith` ones since it is available in both JUnit versions. This fix makes any annotation used in JUnit 4 be replaced with `RunWith`, while for JUnit 5 replaces it with `ExtendWith`(which is a superset of runWith).  Also introduces more logical variable naming.

# Why is a merge request needed
These changes have the potential to lower the amount of compilation errors for JUnit 5 tests, in case of using unique for `ExtenWith` annotation APIs.

# Other notes
Closes #160

- [x] I have checked that I am merging into the correct branch
