### PR TITLE
[#441] Extract classPaths to a tempfile + fix command path with space

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -44,7 +44,7 @@ class JavaTestCompiler(
     ): ExecutionResult {
         val classPathsList = getClassPaths(projectBuildPath)
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
-        val classPaths = "@$fileName"
+        val classPaths = "\"@$fileName\""
 
         // compile file
         // See: https://github.com/JetBrains-Research/TestSpark/issues/402

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -42,7 +42,7 @@ class JavaTestCompiler(
         projectBuildPath: String,
         workingDir: String,
     ): ExecutionResult {
-        val classPathsList = "\"${getClassPaths(projectBuildPath)}\""
+        val classPathsList = "\"${getClassPaths(projectBuildPath).replace("\\", "/")}\""
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
         val classPaths = "\"@$fileName\""
 

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -42,7 +42,10 @@ class JavaTestCompiler(
         projectBuildPath: String,
         workingDir: String,
     ): ExecutionResult {
-        val classPaths = "\"${getClassPaths(projectBuildPath)}\""
+        val classPathsList = getClassPaths(projectBuildPath)
+        val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
+        val classPaths = "@$fileName"
+
         // compile file
         // See: https://github.com/JetBrains-Research/TestSpark/issues/402
         val javac = if (DataFilesUtil.isWindows()) "\"$javac\"" else "'$javac'"

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/java/JavaTestCompiler.kt
@@ -42,7 +42,7 @@ class JavaTestCompiler(
         projectBuildPath: String,
         workingDir: String,
     ): ExecutionResult {
-        val classPathsList = getClassPaths(projectBuildPath)
+        val classPathsList = "\"${getClassPaths(projectBuildPath)}\""
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
         val classPaths = "\"@$fileName\""
 

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -59,7 +59,9 @@ class KotlinTestCompiler(
     ): ExecutionResult {
         logger.info { "[KotlinTestCompiler] Compiling ${path.substringAfterLast('/')}" }
 
-        val classPaths = "\"${getClassPaths(projectBuildPath)}\""
+        val classPathsList = getClassPaths(projectBuildPath)
+        val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
+        val classPaths = "@$fileName"
 
         // We need to ensure JAVA is in the path variable
         // See: https://github.com/JetBrains-Research/TestSpark/issues/410

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -59,7 +59,7 @@ class KotlinTestCompiler(
     ): ExecutionResult {
         logger.info { "[KotlinTestCompiler] Compiling ${path.substringAfterLast('/')}" }
 
-        val classPathsList = getClassPaths(projectBuildPath)
+        val classPathsList = "\"${getClassPaths(projectBuildPath)}\""
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
         val classPaths = "\"@$fileName\""
 

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -59,7 +59,7 @@ class KotlinTestCompiler(
     ): ExecutionResult {
         logger.info { "[KotlinTestCompiler] Compiling ${path.substringAfterLast('/')}" }
 
-        val classPathsList = "\"${getClassPaths(projectBuildPath)}\""
+        val classPathsList = "\"${getClassPaths(projectBuildPath).replace("\\", "/")}\""
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
         val classPaths = "\"@$fileName\""
 

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/test/kotlin/KotlinTestCompiler.kt
@@ -61,7 +61,7 @@ class KotlinTestCompiler(
 
         val classPathsList = getClassPaths(projectBuildPath)
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
-        val classPaths = "@$fileName"
+        val classPaths = "\"@$fileName\""
 
         // We need to ensure JAVA is in the path variable
         // See: https://github.com/JetBrains-Research/TestSpark/issues/410

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/utils/CommandLineRunner.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/utils/CommandLineRunner.kt
@@ -18,6 +18,7 @@ class CommandLineRunner {
         fun run(cmd: ArrayList<String>): ExecutionResult {
             var executionMsg = ""
 
+            log.info { "Running command: ${cmd.joinToString(" ")}" }
             /**
              * Since Windows does not provide bash, use cmd or simila       r default command line interpreter
              */
@@ -28,7 +29,6 @@ class CommandLineRunner {
                         .redirectErrorStream(true)
                         .start()
                 } else {
-                    log.info { "Running command: ${cmd.joinToString(" ")}" }
                     ProcessBuilder()
                         .command("bash", "-c", cmd.joinToString(" "))
                         .redirectErrorStream(true)

--- a/core/src/main/kotlin/org/jetbrains/research/testspark/core/utils/DataFilesUtil.kt
+++ b/core/src/main/kotlin/org/jetbrains/research/testspark/core/utils/DataFilesUtil.kt
@@ -43,6 +43,16 @@ class DataFilesUtil {
             folder.delete()
         }
 
+        fun makeTmpFile(
+            prefix: String,
+            content: String,
+        ): String {
+            val tmpFile = File.createTempFile(prefix, ".tmp")
+            tmpFile.writeText(content)
+            tmpFile.deleteOnExit()
+            return tmpFile.absolutePath
+        }
+
         val classpathSeparator: Char
             get() {
                 var sep = ':'

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -107,7 +107,7 @@ class TestProcessor(
                 projectBuildPath,
             ) + "${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath"
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
-        val classPaths = "@$fileName"
+        val classPaths = "\"@$fileName\""
 
         val testExecutionResult =
             CommandLineRunner.run(

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -105,9 +105,12 @@ class TestProcessor(
 
         // save classpaths to a temp file
         val classPathsList =
-            testCompiler.getClassPaths(
-                projectBuildPath,
-            ) + "${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath"
+            "\"" +
+                testCompiler.getClassPaths(
+                    projectBuildPath,
+                ) +
+                "${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath" +
+                "\""
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
         val classPaths = "\"@$fileName\""
 

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -100,15 +100,22 @@ class TestProcessor(
             } else {
                 "-javaagent:$jacocoAgentLibraryPath=destfile=$dataFileName.exec,append=false"
             }
+
+        // save classpaths to a temp file
+        val classPathsList =
+            testCompiler.getClassPaths(
+                projectBuildPath,
+            ) + "${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath"
+        val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)
+        val classPaths = "@$fileName"
+
         val testExecutionResult =
             CommandLineRunner.run(
                 arrayListOf(
                     javaRunner.absolutePath,
                     javaAgentFlag,
                     "-cp",
-                    "\"${testCompiler.getClassPaths(
-                        projectBuildPath,
-                    )}${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath\"",
+                    classPaths,
                     "org.jetbrains.research.SingleJUnitTestRunner${junitVersion.version}",
                     name,
                 ),

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -112,7 +112,7 @@ class TestProcessor(
         val testExecutionResult =
             CommandLineRunner.run(
                 arrayListOf(
-                    javaRunner.absolutePath,
+                    "\"${javaRunner.absolutePath}\"",
                     javaAgentFlag,
                     "-cp",
                     classPaths,
@@ -126,7 +126,7 @@ class TestProcessor(
         // Prepare the command for generating the Jacoco report
         val command =
             mutableListOf(
-                javaRunner.absolutePath,
+                "\"${javaRunner.absolutePath}\"",
                 "-jar",
                 // jacocoCLIDir,
                 jacocoCLILibraryPath,

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -79,7 +79,9 @@ class TestProcessor(
         junitVersion: JUnitVersion,
     ): String {
         // find the proper javac
-        val javaRunner = findJavaCompilerInDirectory(homeDirectory)
+        val javaRunnerFile = findJavaCompilerInDirectory(homeDirectory)
+        val javaRunnerAbsolutePath = javaRunnerFile.absolutePath
+        val javaRunner = if (DataFilesUtil.isWindows()) "\"$javaRunnerAbsolutePath\"" else "'$javaRunnerAbsolutePath'"
         // JaCoCo libs
         val jacocoAgentLibraryPath = "\"${LibraryPathsProvider.getJacocoAgentLibraryPath()}\""
         val jacocoCLILibraryPath = "\"${LibraryPathsProvider.getJacocoCliLibraryPath()}\""
@@ -112,7 +114,7 @@ class TestProcessor(
         val testExecutionResult =
             CommandLineRunner.run(
                 arrayListOf(
-                    "\"${javaRunner.absolutePath}\"",
+                    javaRunner,
                     javaAgentFlag,
                     "-cp",
                     classPaths,
@@ -126,7 +128,7 @@ class TestProcessor(
         // Prepare the command for generating the Jacoco report
         val command =
             mutableListOf(
-                "\"${javaRunner.absolutePath}\"",
+                javaRunner,
                 "-jar",
                 // jacocoCLIDir,
                 jacocoCLILibraryPath,

--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/TestProcessor.kt
@@ -106,9 +106,10 @@ class TestProcessor(
         // save classpaths to a temp file
         val classPathsList =
             "\"" +
-                testCompiler.getClassPaths(
-                    projectBuildPath,
-                ) +
+                testCompiler
+                    .getClassPaths(
+                        projectBuildPath,
+                    ).replace("\\", "/") +
                 "${DataFilesUtil.classpathSeparator}${junitRunnerLibraryPath}${DataFilesUtil.classpathSeparator}$resultPath" +
                 "\""
         val fileName = DataFilesUtil.makeTmpFile("testSparkCP", classPathsList)


### PR DESCRIPTION
# Description of changes made

To avoid 8191 characters limit when running a command with cmd. The classpaths are not inline but in a temporary file. [Documentation](https://docs.oracle.com/en/java/javase/17/docs/specs/man/javac.html#command-line-argument-files)

And I've wrapped the java executable used for JaCoCo part.

# Why is merge request needed

This PR allows TestSpark to run on Windows. 

# Other notes

Closes #441 

We could write all the arguments in the argFile if we wanted.

# What is missing?

I haven't tested these changes on Linux or macOS, but I haven't found any documentation prohibiting the use of argFile.

- [x] I have checked that I am merging into correct branch
