### PR TITLE
[481] Handle specific error for prompt size exceeding model limit for grazie models

### DIFF
--- a/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
+++ b/src/main/kotlin/org/jetbrains/research/testspark/tools/llm/generation/grazie/GrazieRequestManager.kt
@@ -44,7 +44,10 @@ class GrazieRequestManager(
                             Result.Failure(
                                 error = LlmError.PromptTooLong,
                             )
-
+                        contains("Provided prompt is too big for this model") && contains("invalid: 412 Precondition Failed") ->
+                            Result.Failure(
+                                error = LlmError.PromptTooLong,
+                            )
                         else ->
                             Result.Failure(
                                 error =


### PR DESCRIPTION
# Description of changes made

Handle "Prompt too long" error for models host on Grazie platform.

# Why is merge request needed

If we use a LLM host on Grazie platform and make a request with a prompt too long, the right error is not return by `GrazieRequestManager` because the error status and the error content is not `invalid: 413 Payload Too Large` but `invalid: 412 Precondition Failed` with `Provided prompt is too big for this model`. 

# Other notes
Closes #481  

This PR causes another issue. When the "prompt too long" error occurs after multiple rounds, a new user message is generated with a smaller context and added to the history.
When we get a "prompt too long" error, no assistant message is added to the chat history. We have two user messages in a row, and we get an error 400: `LLama model only supports chat with alternating user/assistant roles`.

But, if we get a "prompt too long" error, add a new message won't solve the issue.

- [x] I have checked that I am merging into correct branch
