### PR TITLE
[#487] Enhance subclass handling by supporting KtLightClass

### DIFF
--- a/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
+++ b/kotlin/src/main/kotlin/org/jetbrains/research/testspark/kotlin/KotlinPsiClassWrapper.kt
@@ -9,6 +9,7 @@ import com.intellij.psi.search.searches.ClassInheritorsSearch
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.concurrency.annotations.RequiresReadLock
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.asJava.classes.KtLightClass
 import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
 import org.jetbrains.kotlin.asJava.toLightClass
 import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
@@ -122,7 +123,7 @@ class KotlinPsiClassWrapper(
             val query = ClassInheritorsSearch.search(lightClass, scope, false)
             query.findAll().filter { it.kotlinFqName != null }.map {
                 // If the sub-class is fetched as an ultra light class, get the KtClass
-                if (it is KtUltraLightClass) {
+                if (it is KtUltraLightClass || it is KtLightClass) {
                     KotlinPsiClassWrapper(it.asKtClassOrObject() as KtClass)
                 } else {
                     KotlinPsiClassWrapper(it as KtClass)


### PR DESCRIPTION
# Description of changes made

Add a new check for `KtLightClass` in addition of `KtUltraLightClass` to avoid trying to cast `SymbolBasedFakeLightClass` as a `KtClass`

# Why is merge request needed

This PR tries to partially fix the issue and allow test generation in kotlin projects that use inheritance

# Other notes
Closes #487

*Please write if you have anything to add*

# What is missing?

Maybe there are other cases not covered? Maybe we need a better error handling here?

- [x] I have checked that I am merging into correct branch
