### PR TITLE
[#490] Filter out anonymous classes in subclass search

### DIFF
--- a/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
+++ b/java/src/main/kotlin/org/jetbrains/research/testspark/java/JavaPsiClassWrapper.kt
@@ -69,7 +69,7 @@ class JavaPsiClassWrapper(
     override fun searchSubclasses(project: Project): Collection<PsiClassWrapper> {
         val scope = GlobalSearchScope.projectScope(project)
         val query = ClassInheritorsSearch.search(psiClass, scope, false)
-        return query.findAll().map { JavaPsiClassWrapper(it) }
+        return query.findAll().filter { it !is PsiAnonymousClass }.map { JavaPsiClassWrapper(it) }
     }
 
     override fun getInterestingPsiClassesWithQualifiedNames(psiMethod: PsiMethodWrapper): MutableSet<PsiClassWrapper> {


### PR DESCRIPTION
# Description of changes made

Previously, the code included anonymous classes in the subclass search results. This change introduces a filter to exclude `PsiAnonymousClass` instances, ensuring only named classes are wrapped and returned. 

# Why is merge request needed

Including anonymous classes produces incomplete polymorphism relationships in the context sent to a LLM.

# Other notes
Closes #490 

# What is missing?
*Please mention if anything is missing for this merge request, e.g you have decided to move something to the next merge request*

- [x] I have checked that I am merging into correct branch
